### PR TITLE
refactor: centralize yes/no prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Tests cover `auth.txt` parsing and gallery generation.
 python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt -r requirements-dev.txt
-pytest -q
+python -m pytest -q
 ```
 
 ---

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -3,6 +3,8 @@ import sys
 import subprocess
 import shutil
 
+from utils import prompt_yes_no
+
 
 def in_venv() -> bool:
     return (
@@ -30,8 +32,7 @@ def main():
     # Create venv if missing
     if not os.path.isdir(venv_dir):
         print('No virtual environment found (.venv).')
-        choice = input('Create one and install requirements now? [Y/n]: ').strip().lower()
-        if choice in ('', 'y', 'yes'):
+        if prompt_yes_no('Create one and install requirements now?'):
             print('Creating virtual environment...')
             subprocess.check_call([sys.executable, '-m', 'venv', venv_dir])
         else:

--- a/incremental_downloader.py
+++ b/incremental_downloader.py
@@ -8,7 +8,7 @@ from glob import glob
 from tqdm import tqdm
 from concurrent.futures import ThreadPoolExecutor
 
-from utils import ensure_auth_config
+from utils import ensure_auth_config, prompt_yes_no
 from gallery import generate_gallery
 
 
@@ -42,8 +42,7 @@ def main():
 
     print(f"Found {len(existing_ids)} previously downloaded image IDs.")
 
-    proceed = input("Proceed to download all new images from your account? [Y/n]: ").strip().lower()
-    if proceed not in ("", "y", "yes"):
+    if not prompt_yes_no("Proceed to download all new images from your account?"):
         print("Aborted by user.")
         return
 
@@ -89,10 +88,9 @@ def main():
         if response.status_code != 200:
             print("Error during fetch:", response.status_code)
             if response.status_code in (401, 403):
-                choice = input(
-                    "Auth seems invalid/expired. Re-enter credentials now? [Y/n]: "
-                ).strip().lower()
-                if choice in ("", "y", "yes"):
+                if prompt_yes_no(
+                    "Auth seems invalid/expired. Re-enter credentials now?"
+                ):
                     config = ensure_auth_config("auth.txt")
                     headers = build_headers(config)
                     continue

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 
-from utils import load_auth_config, ensure_auth_config
+from utils import load_auth_config, ensure_auth_config, prompt_yes_no
 
 
 def write_auth(tmpdir, content: str):
@@ -46,4 +46,21 @@ def test_ensure_auth_config_raises_on_missing_when_user_declines(monkeypatch):
         except FileNotFoundError:
             raised = True
         assert raised
+
+
+def test_prompt_yes_no_respects_defaults(monkeypatch):
+    # default True when user presses enter
+    monkeypatch.setattr('builtins.input', lambda _: '')
+    assert prompt_yes_no('continue?') is True
+
+    # default False when user presses enter
+    monkeypatch.setattr('builtins.input', lambda _: '')
+    assert prompt_yes_no('continue?', default=False) is False
+
+
+def test_prompt_yes_no_parses_input(monkeypatch):
+    inputs = iter(['y', 'n'])
+    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+    assert prompt_yes_no('q?', default=False) is True
+    assert prompt_yes_no('q?', default=True) is False
 

--- a/utils.py
+++ b/utils.py
@@ -13,6 +13,29 @@ REQUIRED_AUTH_KEYS = [
 ]
 
 
+def prompt_yes_no(message: str, default: bool = True) -> bool:
+    """Prompt the user with a yes/no question.
+
+    Args:
+        message: The question to display to the user.
+        default: The return value if the user just hits enter.
+
+    Returns:
+        ``True`` for yes and ``False`` for no.
+    """
+
+    prompt = f"{message} [{'Y/n' if default else 'y/N'}]: "
+    while True:
+        choice = input(prompt).strip().lower()
+        if not choice:
+            return default
+        if choice in ('y', 'yes'):
+            return True
+        if choice in ('n', 'no'):
+            return False
+        print("Please enter 'y' or 'n'.")
+
+
 def load_auth_config(path: str = 'auth.txt') -> dict:
     """Load key=value lines from auth.txt into a dict.
     Ignores lines without '=' and whitespace-only lines.
@@ -57,8 +80,7 @@ def ensure_auth_config(path: str = 'auth.txt') -> dict:
     try:
         cfg = load_auth_config(path)
     except FileNotFoundError:
-        choice = input('auth.txt not found. Create it now? [Y/n]: ').strip().lower()
-        if choice in ('', 'y', 'yes'):
+        if prompt_yes_no('auth.txt not found. Create it now?'):
             cfg = prompt_and_write_auth(path)
         else:
             raise
@@ -67,8 +89,7 @@ def ensure_auth_config(path: str = 'auth.txt') -> dict:
     missing = [k for k in REQUIRED_AUTH_KEYS if not cfg.get(k)]
     if missing:
         print(f"auth.txt is missing keys: {', '.join(missing)}")
-        choice = input('Re-enter credentials now? [Y/n]: ').strip().lower()
-        if choice in ('', 'y', 'yes'):
+        if prompt_yes_no('Re-enter credentials now?'):
             cfg = prompt_and_write_auth(path)
         else:
             raise ValueError(f"Missing required keys: {missing}")


### PR DESCRIPTION
## Summary
- add `prompt_yes_no` utility and refactor existing prompts to use it
- cover new prompt helper in tests and update docs

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c674a4beac832f9ebae85abcbebb67