### PR TITLE
feat: unify CLI with auto-confirm option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Recommended: use a virtual environment.
 Option A — one command bootstrap (creates `.venv`, installs deps, runs):
 
 ```
-python bootstrap.py
+python main.py bootstrap
 ```
 
 Option B — manual setup:
@@ -80,7 +80,7 @@ oai_language=...
 1. **Run with venv bootstrap (recommended)**
 
 ```bash
-python bootstrap.py
+python main.py bootstrap
 ```
 - Creates `.venv`, installs dependencies, and runs the full flow
 
@@ -91,16 +91,7 @@ python main.py
 ```
 - Downloads **only new images**, creates `gallery/vN/`, `images/`, `metadata_vN.json`, and regenerates gallery pages and `gallery/index.html`
 
-### 🧭 Single Step:
-
-```bash
-python incremental_downloader.py
-```
-
-- Scans all existing `v*/metadata_v*.json`
-- Downloads **only new images**
-- Creates `gallery/vN/`, `images/`, `metadata_vN.json`
-- Regenerates gallery pages and `gallery/index.html`
+Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 
 ---
 
@@ -143,6 +134,6 @@ python -m pytest -q
 
 ## ✅ You're All Set
 
-Once configured, rerun `main.py` or `incremental_downloader.py` any time you generate new images in ChatGPT.
+Once configured, rerun `python main.py` any time you generate new images in ChatGPT.
 
 Happy archiving!

--- a/main.py
+++ b/main.py
@@ -1,12 +1,54 @@
-import subprocess
-import sys
+"""Unified command-line interface for ChatGPT Library Archiver.
 
-print("=== ChatGPT Gallery Archiver ===")
+This script consolidates the various helper scripts into a single entry
+point. By default it downloads new images and regenerates the gallery.
+Use the ``bootstrap`` subcommand to create a virtual environment and
+install dependencies before running the downloader.
 
-script = "incremental_downloader.py"
-print(f"\n>>> Downloading new images and regenerating gallery...")
-result = subprocess.run([sys.executable, script])
-if result.returncode == 0:
-    print("\nAll steps completed successfully.")
-else:
-    print(f"Error running {script}")
+The ``-y/--yes`` flag can be used to automatically answer ``yes`` to any
+interactive prompts.
+"""
+
+import argparse
+import os
+
+import bootstrap
+import incremental_downloader
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="ChatGPT Library Archiver")
+    parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Automatically answer yes to confirmation prompts.",
+    )
+
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser(
+        "bootstrap",
+        help="Create a virtual environment, install requirements, and run the downloader",
+    )
+    sub.add_parser(
+        "download",
+        help="Download new images and regenerate the gallery (default)",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.yes:
+        os.environ["ARCHIVER_ASSUME_YES"] = "1"
+
+    if args.command == "bootstrap":
+        bootstrap.main()
+    else:
+        incremental_downloader.main()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,3 +64,9 @@ def test_prompt_yes_no_parses_input(monkeypatch):
     assert prompt_yes_no('q?', default=False) is True
     assert prompt_yes_no('q?', default=True) is False
 
+
+def test_prompt_yes_no_autoconfirm(monkeypatch):
+    monkeypatch.setenv('ARCHIVER_ASSUME_YES', '1')
+    # Should return True without prompting
+    assert prompt_yes_no('skip?') is True
+

--- a/utils.py
+++ b/utils.py
@@ -13,8 +13,15 @@ REQUIRED_AUTH_KEYS = [
 ]
 
 
+# Environment variable to automatically answer yes to prompts
+ASSUME_YES_ENV = "ARCHIVER_ASSUME_YES"
+
+
 def prompt_yes_no(message: str, default: bool = True) -> bool:
     """Prompt the user with a yes/no question.
+
+    If ``ARCHIVER_ASSUME_YES`` is set to a truthy value (``1``, ``true``,
+    ``yes``), the prompt is bypassed and ``True`` is returned immediately.
 
     Args:
         message: The question to display to the user.
@@ -23,6 +30,11 @@ def prompt_yes_no(message: str, default: bool = True) -> bool:
     Returns:
         ``True`` for yes and ``False`` for no.
     """
+
+    assume = os.environ.get(ASSUME_YES_ENV, "").lower()
+    if assume in {"1", "true", "yes"}:
+        print(f"{message} [Y/n]: y (auto)")
+        return True
 
     prompt = f"{message} [{'Y/n' if default else 'y/N'}]: "
     while True:


### PR DESCRIPTION
## Summary
- replace multiple entry scripts with a unified `main.py` CLI
- allow skipping interactive prompts via `-y/--yes` and `ARCHIVER_ASSUME_YES`
- document new usage and add tests for auto-confirm behaviour

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6769844c0832f8133fc98abaf7ec3