### PR TITLE
Add offline end-to-end test for downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ General estimate:
 
 ## 🧪 Tests
 
-Tests cover `auth.txt` parsing and gallery generation.
+Tests cover `auth.txt` parsing, gallery generation, and a full end-to-end
+flow with mocked network calls so the suite runs entirely offline.
 
 ```
 python -m venv .venv

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ General estimate:
 
 Tests cover `auth.txt` parsing, gallery generation, and a full end-to-end
 flow with mocked network calls so the suite runs entirely offline.
+Network requests in these tests use strict URL parsing to avoid
+ambiguous domain matches.
 
 ```
 python -m venv .venv

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 
@@ -47,7 +48,8 @@ def test_incremental_download_and_gallery(monkeypatch, tmp_path):
     calls = {"meta": 0}
 
     def fake_get(url, headers=None, timeout=None):
-        if url.startswith("https://api.example.com"):
+        parsed = urlparse(url)
+        if parsed.scheme == "https" and parsed.netloc == "api.example.com":
             calls["meta"] += 1
             if calls["meta"] == 1:
                 return FakeResponse(

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,91 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from chatgpt_library_archiver import incremental_downloader
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, json_data=None, content=b"", headers=None):
+        self.status_code = status_code
+        self._json = json_data or {}
+        self.content = content
+        self.headers = headers or {}
+
+    def json(self):
+        return self._json
+
+
+def test_incremental_download_and_gallery(monkeypatch, tmp_path):
+    # Operate within a temporary working directory
+    monkeypatch.chdir(tmp_path)
+
+    # Provide dummy auth configuration without touching the filesystem
+    monkeypatch.setattr(
+        incremental_downloader,
+        "ensure_auth_config",
+        lambda path="auth.txt": {
+            "url": "https://api.example.com?limit=1",
+            "authorization": "Bearer token",
+            "cookie": "session=abc",
+            "referer": "https://chat.openai.com/library",
+            "user_agent": "agent",
+            "oai_client_version": "1",
+            "oai_device_id": "dev",
+            "oai_language": "en",
+        },
+    )
+
+    # Auto-confirm all prompts
+    monkeypatch.setattr(incremental_downloader, "prompt_yes_no", lambda msg: True)
+
+    # Avoid real delays during the test
+    monkeypatch.setattr(incremental_downloader.time, "sleep", lambda s: None)
+
+    # Mock network requests for both metadata and image download
+    calls = {"meta": 0}
+
+    def fake_get(url, headers=None, timeout=None):
+        if url.startswith("https://api.example.com"):
+            calls["meta"] += 1
+            if calls["meta"] == 1:
+                return FakeResponse(
+                    json_data={
+                        "items": [
+                            {
+                                "id": "1",
+                                "url": "https://img.local/1.jpg",
+                                "title": "test image",
+                                "created_at": 1,
+                            }
+                        ]
+                    }
+                )
+            else:
+                return FakeResponse(json_data={"items": []})
+        elif url == "https://img.local/1.jpg":
+            return FakeResponse(
+                content=b"img",
+                headers={"Content-Type": "image/jpeg"},
+            )
+        raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr(incremental_downloader.requests, "get", fake_get)
+
+    # Run the full download + gallery generation flow
+    incremental_downloader.main()
+
+    img_path = tmp_path / "gallery" / "v1" / "images" / "1.jpg"
+    meta_path = tmp_path / "gallery" / "v1" / "metadata_v1.json"
+    html_path = tmp_path / "gallery" / "page_1.html"
+
+    assert img_path.exists()
+    assert meta_path.exists()
+    assert html_path.exists()
+
+    data = json.loads(meta_path.read_text())
+    assert data[0]["id"] == "1"
+
+    html = html_path.read_text()
+    assert "v1/images/1.jpg" in html


### PR DESCRIPTION
## Summary
- add end-to-end test that runs incremental downloader and gallery generation with mocked network calls
- document offline tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c681547fb4832f97599a06751cd7a2