### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
## Summary
- configure Dependabot to check pip packages and GitHub Actions weekly
- remove README mention of Dependabot per review

## Testing
- `pre-commit run --files README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c687b081a8832fa4cf5f2a84e28e9b