### PR TITLE
Consolidate legacy gallery storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This is a Python-based toolset for downloading, archiving, and browsing images g
 
 ---
 
+## ⚠️ Temporary Note
+
+Existing galleries using legacy versioned folders will be migrated into the unified
+`gallery/images` and `gallery/metadata.json` locations on the next run. This is a
+one-time move to ensure all images are displayed and linked correctly.
+
 ## 📦 Folder Structure
 
 ```

--- a/src/chatgpt_library_archiver/incremental_downloader.py
+++ b/src/chatgpt_library_archiver/incremental_downloader.py
@@ -3,13 +3,12 @@ import mimetypes
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor
-from glob import glob
 from urllib.parse import quote
 
 import requests
 from tqdm import tqdm
 
-from .gallery import generate_gallery
+from .gallery import consolidate_legacy_storage, generate_gallery
 from .utils import ensure_auth_config, prompt_yes_no
 
 
@@ -37,6 +36,7 @@ def main():
     images_dir = os.path.join("gallery", "images")
     os.makedirs(images_dir, exist_ok=True)
 
+    consolidate_legacy_storage("gallery")
     existing_ids = set()
     existing_metadata = []
     metadata_path = os.path.join("gallery", "metadata.json")
@@ -44,15 +44,6 @@ def main():
         with open(metadata_path, encoding="utf-8") as f:
             existing_metadata = json.load(f)
             existing_ids.update(item["id"] for item in existing_metadata)
-
-    # Backward compatibility: load legacy versioned metadata
-    for path in sorted(glob("gallery/v*/metadata_v*.json")):
-        with open(path, encoding="utf-8") as f:
-            data = json.load(f)
-            for item in data:
-                if item["id"] not in existing_ids:
-                    existing_ids.add(item["id"])
-                    existing_metadata.append(item)
 
     print(f"Found {len(existing_ids)} previously downloaded image IDs.")
 

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -36,3 +36,23 @@ def test_generate_gallery_includes_all_images(tmp_path):
     # old image should still appear on second page
     html2 = (gallery_root / "page_2.html").read_text()
     assert "images/a.jpg" in html2
+
+
+def test_consolidates_legacy_metadata(tmp_path):
+    gallery_root = tmp_path / "gallery"
+    legacy = gallery_root / "v1"
+    (legacy / "images").mkdir(parents=True)
+
+    meta = [{"id": "1", "filename": "a.jpg", "created_at": 1}]
+    with open(legacy / "metadata_v1.json", "w", encoding="utf-8") as f:
+        json.dump(meta, f)
+    (legacy / "images" / "a.jpg").write_text("img")
+
+    generate_gallery(str(gallery_root), images_per_page=1)
+
+    assert not legacy.exists()
+    assert (gallery_root / "images" / "a.jpg").exists()
+    data = json.loads((gallery_root / "metadata.json").read_text())
+    assert data[0]["id"] == "1"
+    html = (gallery_root / "page_1.html").read_text()
+    assert "images/a.jpg" in html


### PR DESCRIPTION
## Summary
- Move any legacy gallery metadata/images into the unified `gallery/images` and `metadata.json` locations
- Drop loading code for legacy folders and always read from the unified store
- Warn users in the README about the one-time migration of existing files
- Add tests covering legacy migration and downloader behavior

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c70bf7918c832fbf4166e540732e27