### PR TITLE
Support gallery-only regeneration via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ python -m chatgpt_library_archiver
 ```
 - Downloads **only new images**, adds them to `gallery/images`, updates `gallery/metadata.json`, and regenerates gallery pages and `gallery/index.html`
 
+3. **Regenerate gallery without downloading**
+
+```bash
+python -m chatgpt_library_archiver gallery
+```
+- Consolidates any legacy media and rebuilds the HTML gallery from existing files
+
 Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 
 ---

--- a/src/chatgpt_library_archiver/__main__.py
+++ b/src/chatgpt_library_archiver/__main__.py
@@ -12,7 +12,7 @@ interactive prompts.
 import argparse
 import os
 
-from . import bootstrap, incremental_downloader
+from . import bootstrap, gallery, incremental_downloader
 
 
 def parse_args() -> argparse.Namespace:
@@ -36,6 +36,10 @@ def parse_args() -> argparse.Namespace:
         "download",
         help="Download new images and regenerate the gallery (default)",
     )
+    sub.add_parser(
+        "gallery",
+        help="Regenerate gallery without downloading new images",
+    )
 
     return parser.parse_args()
 
@@ -47,6 +51,12 @@ def main() -> None:
 
     if args.command == "bootstrap":
         bootstrap.main()
+    elif args.command == "gallery":
+        total = gallery.generate_gallery()
+        if total:
+            print(f"Generated gallery with {total} images.")
+        else:
+            print("No gallery generated (no images found).")
     else:
         incremental_downloader.main()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,37 @@
+import json
+import sys
+from pathlib import Path
+
+from chatgpt_library_archiver import incremental_downloader
+
+
+def test_gallery_subcommand(monkeypatch, tmp_path):
+    # Run within temporary directory
+    monkeypatch.chdir(tmp_path)
+
+    # Ensure downloader is not invoked
+    def fail():  # pragma: no cover - should not be called
+        raise AssertionError("incremental downloader should not run")
+
+    monkeypatch.setattr(incremental_downloader, "main", fail)
+
+    # Seed legacy gallery structure
+    legacy = Path("gallery") / "v1"
+    (legacy / "images").mkdir(parents=True)
+    (legacy / "images" / "a.jpg").write_text("img")
+    with open(legacy / "metadata_v1.json", "w", encoding="utf-8") as f:
+        json.dump([{"id": "1", "filename": "a.jpg", "created_at": 1}], f)
+
+    # Invoke CLI to regenerate gallery
+    monkeypatch.setattr(sys, "argv", ["chatgpt_library_archiver", "gallery"])
+    import importlib
+
+    cli = importlib.import_module("chatgpt_library_archiver.__main__")
+    cli.main()
+
+    # Legacy directory removed and unified gallery generated
+    assert not legacy.exists()
+    assert Path("gallery/images/a.jpg").exists()
+    data = json.loads(Path("gallery/metadata.json").read_text())
+    assert data[0]["id"] == "1"
+    assert Path("gallery/page_1.html").exists()


### PR DESCRIPTION
## Summary
- expose a new `gallery` subcommand so the CLI can rebuild the HTML gallery without downloading new images
- document the gallery command in the README
- test that the gallery subcommand consolidates legacy media and regenerates pages

## Testing
- `pre-commit run --files src/chatgpt_library_archiver/__main__.py tests/test_cli.py README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c70f0f1f1c832f83a11a7489d227b3