### PR TITLE
Remove legacy media migration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This is a Python-based toolset for downloading, archiving, and browsing images g
 
 ---
 
-## ⚠️ Temporary Note
+## ⚠️ Note
 
-Existing galleries using legacy versioned folders will be migrated into the unified
-`gallery/images` and `gallery/metadata.json` locations on the next run. This is a
-one-time move to ensure all images are displayed and linked correctly.
+Support for legacy versioned gallery folders (`v1`, `v2`, etc.) has been removed.
+If you're upgrading from an older release that used those directories, re-download
+your images with this version or run a previous release to migrate your data.
 
 ## 📦 Folder Structure
 
@@ -99,7 +99,7 @@ python -m chatgpt_library_archiver
 ```bash
 python -m chatgpt_library_archiver gallery
 ```
-- Consolidates any legacy media and rebuilds the HTML gallery from existing files
+- Rebuilds the HTML gallery from existing files
 
 Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 

--- a/src/chatgpt_library_archiver/gallery.py
+++ b/src/chatgpt_library_archiver/gallery.py
@@ -1,67 +1,7 @@
 import json
 import os
-import shutil
 from datetime import datetime
 from typing import Dict, List
-
-
-def consolidate_legacy_storage(gallery_root: str) -> bool:
-    """Move legacy versioned data into unified locations.
-
-    Returns True if any legacy data was consolidated.
-    """
-    moved = False
-    if not os.path.isdir(gallery_root):
-        return moved
-
-    images_dir = os.path.join(gallery_root, "images")
-    os.makedirs(images_dir, exist_ok=True)
-
-    # Load existing unified metadata
-    meta_path = os.path.join(gallery_root, "metadata.json")
-    existing = []
-    if os.path.isfile(meta_path):
-        with open(meta_path, encoding="utf-8") as f:
-            existing = json.load(f)
-    existing_ids = {item.get("id") for item in existing}
-
-    versions = [
-        d
-        for d in os.listdir(gallery_root)
-        if d.startswith("v") and os.path.isdir(os.path.join(gallery_root, d))
-    ]
-
-    for version in versions:
-        version_dir = os.path.join(gallery_root, version)
-        legacy_meta_path = os.path.join(version_dir, f"metadata_{version}.json")
-        if not os.path.isfile(legacy_meta_path):
-            continue
-
-        with open(legacy_meta_path, encoding="utf-8") as f:
-            data = json.load(f)
-
-        for item in data:
-            image_name = item.get("filename")
-            if not image_name or item.get("id") in existing_ids:
-                continue
-
-            src_img = os.path.join(version_dir, "images", image_name)
-            dst_img = os.path.join(images_dir, image_name)
-            if os.path.isfile(src_img) and not os.path.exists(dst_img):
-                shutil.move(src_img, dst_img)
-
-            existing.append(item)
-            existing_ids.add(item.get("id"))
-            moved = True
-
-        # Remove the processed legacy directory
-        shutil.rmtree(version_dir, ignore_errors=True)
-
-    if moved:
-        with open(meta_path, "w", encoding="utf-8") as f:
-            json.dump(existing, f, indent=2)
-
-    return moved
 
 
 def _load_all_metadata(gallery_root: str) -> List[Dict]:
@@ -220,7 +160,6 @@ def _generate_index(num_pages: int) -> str:
 
 def generate_gallery(gallery_root: str = "gallery", images_per_page: int = 500) -> int:
     os.makedirs(gallery_root, exist_ok=True)
-    consolidate_legacy_storage(gallery_root)
     items = _load_all_metadata(gallery_root)
     if not items:
         return 0

--- a/src/chatgpt_library_archiver/incremental_downloader.py
+++ b/src/chatgpt_library_archiver/incremental_downloader.py
@@ -8,7 +8,7 @@ from urllib.parse import quote
 import requests
 from tqdm import tqdm
 
-from .gallery import consolidate_legacy_storage, generate_gallery
+from .gallery import generate_gallery
 from .utils import ensure_auth_config, prompt_yes_no
 
 
@@ -36,7 +36,6 @@ def main():
     images_dir = os.path.join("gallery", "images")
     os.makedirs(images_dir, exist_ok=True)
 
-    consolidate_legacy_storage("gallery")
     existing_ids = set()
     existing_metadata = []
     metadata_path = os.path.join("gallery", "metadata.json")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,11 +15,11 @@ def test_gallery_subcommand(monkeypatch, tmp_path):
 
     monkeypatch.setattr(incremental_downloader, "main", fail)
 
-    # Seed legacy gallery structure
-    legacy = Path("gallery") / "v1"
-    (legacy / "images").mkdir(parents=True)
-    (legacy / "images" / "a.jpg").write_text("img")
-    with open(legacy / "metadata_v1.json", "w", encoding="utf-8") as f:
+    # Seed existing gallery data
+    gallery = Path("gallery")
+    (gallery / "images").mkdir(parents=True)
+    (gallery / "images" / "a.jpg").write_text("img")
+    with open(gallery / "metadata.json", "w", encoding="utf-8") as f:
         json.dump([{"id": "1", "filename": "a.jpg", "created_at": 1}], f)
 
     # Invoke CLI to regenerate gallery
@@ -29,8 +29,7 @@ def test_gallery_subcommand(monkeypatch, tmp_path):
     cli = importlib.import_module("chatgpt_library_archiver.__main__")
     cli.main()
 
-    # Legacy directory removed and unified gallery generated
-    assert not legacy.exists()
+    # Gallery regenerated from existing metadata
     assert Path("gallery/images/a.jpg").exists()
     data = json.loads(Path("gallery/metadata.json").read_text())
     assert data[0]["id"] == "1"

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -41,12 +41,12 @@ def test_incremental_download_and_gallery(monkeypatch, tmp_path):
     # Avoid real delays during the test
     monkeypatch.setattr(incremental_downloader.time, "sleep", lambda s: None)
 
-    # Seed legacy data
-    legacy = tmp_path / "gallery" / "v1" / "images"
-    legacy.mkdir(parents=True)
-    (legacy / "1.jpg").write_bytes(b"old")
-    meta_v1 = tmp_path / "gallery" / "v1" / "metadata_v1.json"
-    with open(meta_v1, "w", encoding="utf-8") as f:
+    # Seed existing data
+    images_dir = tmp_path / "gallery" / "images"
+    images_dir.mkdir(parents=True)
+    (images_dir / "1.jpg").write_bytes(b"old")
+    meta_path = tmp_path / "gallery" / "metadata.json"
+    with open(meta_path, "w", encoding="utf-8") as f:
         json.dump([{"id": "1", "filename": "1.jpg", "created_at": 1}], f)
 
     # Mock network requests for both metadata and image download

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -36,23 +36,3 @@ def test_generate_gallery_includes_all_images(tmp_path):
     # old image should still appear on second page
     html2 = (gallery_root / "page_2.html").read_text()
     assert "images/a.jpg" in html2
-
-
-def test_consolidates_legacy_metadata(tmp_path):
-    gallery_root = tmp_path / "gallery"
-    legacy = gallery_root / "v1"
-    (legacy / "images").mkdir(parents=True)
-
-    meta = [{"id": "1", "filename": "a.jpg", "created_at": 1}]
-    with open(legacy / "metadata_v1.json", "w", encoding="utf-8") as f:
-        json.dump(meta, f)
-    (legacy / "images" / "a.jpg").write_text("img")
-
-    generate_gallery(str(gallery_root), images_per_page=1)
-
-    assert not legacy.exists()
-    assert (gallery_root / "images" / "a.jpg").exists()
-    data = json.loads((gallery_root / "metadata.json").read_text())
-    assert data[0]["id"] == "1"
-    html = (gallery_root / "page_1.html").read_text()
-    assert "images/a.jpg" in html


### PR DESCRIPTION
## Summary
- drop legacy `v*` gallery consolidation and related code
- simplify downloader to operate on existing unified storage
- document removal of legacy support and guide users on upgrading

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c711e74dfc832f83a7f740510780d4