### PR TITLE
feat: add image lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 - The gallery is fully static and self-contained.
 - The `index.html` viewer is bundled with the tool and reused on each run.
 - `gallery/index.html` loads `metadata.json` via JavaScript and displays all images on one page.
+- Images are lazy-loaded using the Intersection Observer API so they're fetched only when they enter the viewport.
 - Use the search bar in the gallery to filter by title or a date range.
 
 ### Disk Space

--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -97,6 +97,15 @@ async function loadImages() {
   const response = await fetch('metadata.json');
   const data = await response.json();
   const gallery = document.getElementById('gallery');
+  const observer = new IntersectionObserver((entries, obs) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        const img = entry.target;
+        img.src = img.dataset.src;
+        obs.unobserve(img);
+      }
+    });
+  });
   data.forEach(item => {
     const card = document.createElement('div');
     card.className = 'image-card';
@@ -114,13 +123,15 @@ async function loadImages() {
     const tags = tagsArr.join(', ') || '—';
     card.innerHTML =
       '<a href="' + imgPath + '" target="_blank">' +
-      '<img src="' + imgPath + '" alt="' + title + '"></a>' +
+      '<img data-src="' + imgPath + '" alt="' + title + '" loading="lazy"></a>' +
       '<div class="meta"><strong>' + (title || item.id) + '</strong><br>' +
       created + '<br>' +
       'Tags: ' + tags + '<br><a href="' +
       (item.conversation_link || '#') +
       '" target="_blank">View conversation</a></div>';
     gallery.appendChild(card);
+    const img = card.querySelector('img');
+    observer.observe(img);
   });
 }
 function toggleDarkMode() {

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -32,6 +32,8 @@ def test_generate_gallery_creates_single_index(tmp_path):
         "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
     )
     assert index.read_text() == expected
+    assert 'loading="lazy"' in expected
+    assert "data-src" in expected
 
     with open(gallery_root / "metadata.json", encoding="utf-8") as f:
         data = json.load(f)


### PR DESCRIPTION
## Summary
- defer gallery image downloads until they enter the viewport using IntersectionObserver
- test generated gallery for lazy-loading attributes
- document lazy-loaded image performance in README

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c72807e150832f80affe9c8fa4380a