### PR TITLE
fix viewer aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 - `gallery/index.html` loads `metadata.json` via JavaScript and displays all images on one page.
 - Images are lazy-loaded using the Intersection Observer API so they're fetched only when they enter the viewport.
 - Use the search bar in the gallery to filter by title or a date range.
- - Click any thumbnail to open a full-screen viewer overlay. Navigate with the left/right
-   arrow keys, press Escape to close, or follow the **Raw file** link to view the
-   underlying image. Ctrl-click (Cmd-click on macOS) a thumbnail to open the raw image
-   directly in a new tab without launching the viewer.
+- Click any thumbnail to open a full-screen viewer overlay that preserves the image's
+  aspect ratio. Navigate with the left/right arrow keys, press Escape to close, or
+  follow the **Raw file** link to view the underlying image. Ctrl-click (Cmd-click on
+  macOS) a thumbnail to open the raw image directly in a new tab without launching the
+  viewer.
 
 ### Disk Space
 This depends entirely on how many images you have.

--- a/README.md
+++ b/README.md
@@ -113,11 +113,10 @@ Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 - `gallery/index.html` loads `metadata.json` via JavaScript and displays all images on one page.
 - Images are lazy-loaded using the Intersection Observer API so they're fetched only when they enter the viewport.
 - Use the search bar in the gallery to filter by title or a date range.
-- Click any thumbnail to open a full-screen viewer overlay that preserves the image's
-  aspect ratio. Navigate with the left/right arrow keys, press Escape to close, or
-  follow the **Raw file** link to view the underlying image. Ctrl-click (Cmd-click on
-  macOS) a thumbnail to open the raw image directly in a new tab without launching the
-  viewer.
+- Click any thumbnail to open a full-screen viewer overlay. Navigate with the left/right
+  arrow keys, press Escape to close, or follow the **Raw file** link to view the
+  underlying image. Ctrl-click (Cmd-click on macOS) a thumbnail to open the raw image
+  directly in a new tab without launching the viewer.
 
 ### Disk Space
 This depends entirely on how many images you have.

--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -77,7 +77,12 @@ body.dark .size-select { background: #555; color: white; }
   align-items: center;
   justify-content: center;
 }
-#viewer img { max-width: 90%; max-height: 90%; }
+#viewer img {
+  max-width: 90%;
+  max-height: 90%;
+  width: auto;
+  height: auto;
+}
 #viewer .viewer-meta { position: absolute; bottom: 20px; }
 #viewer a {
   color: white;

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -1,4 +1,5 @@
 import json
+import re
 import subprocess
 import textwrap
 from importlib import resources
@@ -15,6 +16,17 @@ def write_metadata(root: Path, items):
 
 def test_gallery_template_packaged():
     assert resources.is_resource("chatgpt_library_archiver", "gallery_index.html")
+
+
+def test_viewer_image_css_preserves_aspect_ratio():
+    html = resources.read_text(
+        "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
+    )
+    match = re.search(r"#viewer img \{[^}]*\}", html)
+    assert match, "viewer img block not found"
+    block = match.group(0)
+    assert "width: auto" in block
+    assert "height: auto" in block
 
 
 def test_generate_gallery_creates_single_index(tmp_path):


### PR DESCRIPTION
## Summary
- ensure fullscreen viewer images preserve their aspect ratio by overriding width and height
- document that the viewer overlay maintains aspect ratio
- add regression test for viewer image sizing

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c72df09310832faf69421c998af2f2