### PR TITLE
Enforce lint and tests via pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Run formatting and linting
+make lint
+
+# Run tests
+make test

--- a/README.md
+++ b/README.md
@@ -153,6 +153,18 @@ pre-commit run --all-files
 pytest
 ```
 
+### Git hook
+
+To ensure linting and tests pass before commits are created, configure Git to
+use the provided hooks:
+
+```
+git config core.hooksPath .githooks
+```
+
+The pre-commit hook runs `make lint` and `make test` and will block the commit
+if either step fails.
+
 To build a distributable package:
 
 ```

--- a/tests/test_pre_commit_hook.py
+++ b/tests/test_pre_commit_hook.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_pre_commit_hook_runs_lint_and_tests():
+    hook_path = Path(__file__).resolve().parent.parent / ".githooks" / "pre-commit"
+    content = hook_path.read_text()
+    assert "make lint" in content
+    assert "make test" in content


### PR DESCRIPTION
## Summary
- add git hook to run lint and tests before commits
- document hook usage and testing instructions
- test that the hook includes lint and test commands

## Testing
- `pre-commit run --files README.md .githooks/pre-commit tests/test_pre_commit_hook.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7344f9308832f894bf4776fca7f01