### PR TITLE
feat: add automatic dark mode with prefers-color-scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 - `gallery/index.html` loads `metadata.json` via JavaScript and displays all images on one page.
 - Images are lazy-loaded using the Intersection Observer API so they're fetched only when they enter the viewport.
 - Use the search bar in the gallery to filter by title or a date range.
+- The gallery respects your system's light or dark preference, and the **Toggle Dark Mode** button lets you override it.
 - Click any thumbnail to open a full-screen viewer overlay. Navigate with the left/right
   arrow keys, press Escape to close, or follow the **Raw file** link to view the
   underlying image. Ctrl-click (Cmd-click on macOS) a thumbnail to open the raw image

--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -66,6 +66,16 @@ body.dark .toggle { background: #555; color: white; }
   font-size: 0.9em;
 }
 body.dark .size-select { background: #555; color: white; }
+@media (prefers-color-scheme: dark) {
+  body:not(.light) {
+    background: #111;
+    color: #eee;
+  }
+  body:not(.light) .image-card { background: #222; }
+  body:not(.light) .meta { color: #ccc; }
+  body:not(.light) .toggle,
+  body:not(.light) .size-select { background: #555; color: white; }
+}
 #viewer {
   position: fixed;
   top: 0;
@@ -174,14 +184,25 @@ async function loadImages() {
   updateVisibleIndices();
 }
 function toggleDarkMode() {
-  document.body.classList.toggle('dark');
-  localStorage.setItem(
-    'theme',
-    document.body.classList.contains('dark') ? 'dark' : 'light'
-  );
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const isDark =
+    document.body.classList.contains('dark') ||
+    (!document.body.classList.contains('light') && prefersDark);
+  if (isDark) {
+    document.body.classList.remove('dark');
+    document.body.classList.add('light');
+    localStorage.setItem('theme', 'light');
+  } else {
+    document.body.classList.remove('light');
+    document.body.classList.add('dark');
+    localStorage.setItem('theme', 'dark');
+  }
 }
-if (localStorage.getItem('theme') === 'dark') {
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme === 'dark') {
   document.body.classList.add('dark');
+} else if (savedTheme === 'light') {
+  document.body.classList.add('light');
 }
 function filterGallery() {
   const text = document.getElementById('searchBox').value.toLowerCase();

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -29,6 +29,13 @@ def test_viewer_image_css_preserves_aspect_ratio():
     assert "height: auto" in block
 
 
+def test_gallery_prefers_color_scheme():
+    html = resources.read_text(
+        "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
+    )
+    assert "@media (prefers-color-scheme: dark)" in html
+
+
 def test_generate_gallery_creates_single_index(tmp_path):
     gallery_root = tmp_path / "gallery"
     gallery_root.mkdir()


### PR DESCRIPTION
## Summary
- respect system color scheme and allow overriding through the toggle
- verify dark-mode media query in the gallery template
- document automatic dark mode in README

## Testing
- `pre-commit run --files src/chatgpt_library_archiver/gallery_index.html tests/test_gallery.py README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c736f6f48c832fa578c5eb1a536637