### PR TITLE
Add OpenAI-based image tagging command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ gallery/
 ├── metadata.json
 └── index.html  ← single-page gallery
 auth.txt        ← credentials for API access
+tagging_config.json ← OpenAI API key, model, and prompt for tagging
 ```
 
 ---
@@ -78,6 +79,25 @@ The interactive setup saves `auth.txt` with permissions `600` (owner read/write 
 
 ---
 
+## 🧩 `tagging_config.json` — OpenAI Tagging Setup
+
+This file supplies the OpenAI API key and options used when generating tags for
+images. It is created automatically on first run of the tagging command, or you
+can create it manually with contents like:
+
+```
+{
+  "api_key": "sk-...",
+  "model": "gpt-4.1-mini",
+  "prompt": "Generate concise, comma-separated tags describing this image."
+}
+```
+
+Only `api_key` is required; `model` and `prompt` have sensible defaults. Keep
+this file private—never commit it to version control.
+
+---
+
 ## 🚀 3. Script Usage
 ### 🧭 Full Flow (Recommended):
 
@@ -97,11 +117,22 @@ python -m chatgpt_library_archiver
 
 3. **Regenerate gallery without downloading**
 
-```bash
-python -m chatgpt_library_archiver gallery
-```
-- Rebuilds the HTML gallery from existing files (sorts metadata and copies the
+ ```bash
+ python -m chatgpt_library_archiver gallery
+ ```
+ - Rebuilds the HTML gallery from existing files (sorts metadata and copies the
   bundled `index.html`)
+
+4. **Generate or manage image tags**
+
+```bash
+python -m chatgpt_library_archiver tag [--all|--ids <id...>|--remove-all|--remove-ids <id...>]
+```
+- Populates the `tags` field in `metadata.json` using the OpenAI API. By
+  default, only images missing tags are processed. Use `--all` to re-tag every
+  image, `--ids` to tag specific images, `--remove-all` to clear tags from all
+  images, or `--remove-ids` to clear tags for specific images. The prompt and
+  model can be overridden with `--prompt` and `--model`.
 
 Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 

--- a/README.md
+++ b/README.md
@@ -104,16 +104,18 @@ this file private—never commit it to version control.
 1. **Run with venv bootstrap (recommended)**
 
 ```bash
-python -m chatgpt_library_archiver bootstrap
+python -m chatgpt_library_archiver bootstrap [--tag-new]
 ```
 - Creates `.venv`, installs dependencies, and runs the full flow
+- Use `--tag-new` to tag newly downloaded images after syncing
 
 2. **Run manually inside venv**
 
 ```bash
-python -m chatgpt_library_archiver
+python -m chatgpt_library_archiver [--tag-new]
 ```
 - Downloads **only new images**, adds them to `gallery/images`, updates `gallery/metadata.json`, and regenerates `gallery/index.html`
+- Add `--tag-new` to tag fresh images during the download
 
 3. **Regenerate gallery without downloading**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ authors = [
 ]
 dependencies = [
   "requests>=2.31.0",
-  "tqdm>=4.66.0"
+  "tqdm>=4.66.0",
+  "openai>=1.0.0"
 ]
 
 [project.optional-dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ build>=1.0.0
 pre-commit>=3.5.0
 pytest>=7.0
 ruff>=0.1.0
+openai>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.31.0
 tqdm>=4.66.0
+openai>=1.0.0

--- a/src/chatgpt_library_archiver/__init__.py
+++ b/src/chatgpt_library_archiver/__init__.py
@@ -1,5 +1,5 @@
 """Top-level package for ChatGPT Library Archiver."""
 
-__all__ = ["bootstrap", "incremental_downloader", "gallery", "utils"]
+__all__ = ["bootstrap", "incremental_downloader", "gallery", "tagger", "utils"]
 
 __version__ = "0.1.0"

--- a/src/chatgpt_library_archiver/__main__.py
+++ b/src/chatgpt_library_archiver/__main__.py
@@ -12,7 +12,7 @@ interactive prompts.
 import argparse
 import os
 
-from . import bootstrap, gallery, incremental_downloader
+from . import bootstrap, gallery, incremental_downloader, tagger
 
 
 def parse_args() -> argparse.Namespace:
@@ -40,6 +40,25 @@ def parse_args() -> argparse.Namespace:
         "gallery",
         help="Regenerate gallery without downloading new images",
     )
+    tag = sub.add_parser(
+        "tag",
+        help="Generate or remove tags for images using OpenAI",
+    )
+    tag.add_argument("--all", action="store_true", help="Re-tag all images")
+    tag.add_argument("--ids", nargs="+", help="Tag only specific image IDs")
+    tag.add_argument(
+        "--remove-all", action="store_true", help="Remove tags from all images"
+    )
+    tag.add_argument(
+        "--remove-ids", nargs="+", help="Remove tags from specific image IDs"
+    )
+    tag.add_argument("--prompt", help="Override tagging prompt")
+    tag.add_argument("--model", help="Override model ID")
+    tag.add_argument(
+        "--config",
+        default="tagging_config.json",
+        help="Path to OpenAI tagging configuration",
+    )
 
     return parser.parse_args()
 
@@ -57,6 +76,12 @@ def main() -> None:
             print(f"Generated gallery with {total} images.")
         else:
             print("No gallery generated (no images found).")
+    elif args.command == "tag":
+        count = tagger.main(args)
+        if count:
+            print(f"Updated tags for {count} images.")
+        else:
+            print("No images processed.")
     else:
         incremental_downloader.main()
 

--- a/src/chatgpt_library_archiver/__main__.py
+++ b/src/chatgpt_library_archiver/__main__.py
@@ -23,18 +23,29 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Automatically answer yes to confirmation prompts.",
     )
+    parser.add_argument(
+        "--tag-new",
+        action="store_true",
+        help="Tag newly downloaded images using OpenAI",
+    )
 
     sub = parser.add_subparsers(dest="command")
-    sub.add_parser(
+    boot = sub.add_parser(
         "bootstrap",
         help=(
             "Create a virtual environment, install requirements, "
             "and run the downloader"
         ),
     )
-    sub.add_parser(
+    boot.add_argument(
+        "--tag-new", action="store_true", help="Tag newly downloaded images"
+    )
+    dl = sub.add_parser(
         "download",
         help="Download new images and regenerate the gallery (default)",
+    )
+    dl.add_argument(
+        "--tag-new", action="store_true", help="Tag newly downloaded images"
     )
     sub.add_parser(
         "gallery",
@@ -69,7 +80,7 @@ def main() -> None:
         os.environ["ARCHIVER_ASSUME_YES"] = "1"
 
     if args.command == "bootstrap":
-        bootstrap.main()
+        bootstrap.main(tag_new=args.tag_new)
     elif args.command == "gallery":
         total = gallery.generate_gallery()
         if total:
@@ -83,7 +94,7 @@ def main() -> None:
         else:
             print("No images processed.")
     else:
-        incremental_downloader.main()
+        incremental_downloader.main(tag_new=args.tag_new)
 
 
 if __name__ == "__main__":

--- a/src/chatgpt_library_archiver/bootstrap.py
+++ b/src/chatgpt_library_archiver/bootstrap.py
@@ -23,7 +23,7 @@ def venv_pip(venv_dir: str) -> str:
     return os.path.join(venv_dir, "bin", "pip")
 
 
-def main():
+def main(tag_new: bool = False):
     project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     venv_dir = os.path.join(project_root, ".venv")
 
@@ -55,7 +55,10 @@ def main():
     # Re-run package CLI inside venv
     py_exe = venv_python(venv_dir)
     print("Launching chatgpt_library_archiver inside the virtual environment...")
-    sys.exit(subprocess.call([py_exe, "-m", "chatgpt_library_archiver"]))
+    cmd = [py_exe, "-m", "chatgpt_library_archiver"]
+    if tag_new:
+        cmd.append("--tag-new")
+    sys.exit(subprocess.call(cmd))
 
 
 if __name__ == "__main__":

--- a/src/chatgpt_library_archiver/incremental_downloader.py
+++ b/src/chatgpt_library_archiver/incremental_downloader.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 import requests
 from tqdm import tqdm
 
+from . import tagger
 from .gallery import generate_gallery
 from .utils import ensure_auth_config, prompt_yes_no
 
@@ -25,7 +26,7 @@ def build_headers(config: dict) -> dict:
     }
 
 
-def main():
+def main(tag_new: bool = False) -> None:
     # Load auth (prompt if missing)
     config = ensure_auth_config("auth.txt")
     base_url = config["url"]
@@ -168,10 +169,14 @@ def main():
         with open(metadata_path, "w", encoding="utf-8") as f:
             json.dump(existing_metadata, f, indent=2)
         print(f"Saved {len(new_metadata)} new images to gallery/")
+        if tag_new:
+            ids = [m["id"] for m in new_metadata]
+            print("Tagging new images...")
+            tagger.tag_images(ids=ids)
     else:
         print("No new images to download.")
 
-    # Regenerate gallery pages and index after downloads
+    # Regenerate gallery pages and index after downloads (including tags)
     generate_gallery()
 
 

--- a/src/chatgpt_library_archiver/tagger.py
+++ b/src/chatgpt_library_archiver/tagger.py
@@ -1,0 +1,149 @@
+import argparse
+import base64
+import json
+import mimetypes
+import os
+from typing import Iterable, List, Optional
+
+from openai import OpenAI
+
+from .utils import prompt_yes_no
+
+DEFAULT_PROMPT = (
+    "Generate concise, comma-separated descriptive tags for this image in the style of"
+    " booru archives."
+)
+
+
+def _load_config(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _write_config(path: str) -> dict:
+    print("\nTagging configuration not found. Let's create it.\n")
+    api_key = input("api_key = ").strip()
+    model = input("model [gpt-4.1-mini] = ").strip() or "gpt-4.1-mini"
+    prompt = input("prompt [leave blank for default] = ").strip() or DEFAULT_PROMPT
+    cfg = {"api_key": api_key, "model": model, "prompt": prompt}
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+    print(f"\nSaved configuration to {path}.\n")
+    return cfg
+
+
+def ensure_tagging_config(path: str = "tagging_config.json") -> dict:
+    try:
+        cfg = _load_config(path)
+    except FileNotFoundError:
+        if prompt_yes_no(f"{path} not found. Create it now?"):
+            cfg = _write_config(path)
+        else:
+            raise
+    if not cfg.get("api_key"):
+        raise ValueError("tagging config missing 'api_key'")
+    cfg.setdefault("model", "gpt-4.1-mini")
+    cfg.setdefault("prompt", DEFAULT_PROMPT)
+    return cfg
+
+
+def generate_tags(
+    image_path: str, client: OpenAI, model: str, prompt: str
+) -> List[str]:
+    mime = mimetypes.guess_type(image_path)[0] or "image/jpeg"
+    with open(image_path, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode("ascii")
+    image_url = f"data:{mime};base64,{b64}"
+    response = client.responses.create(
+        model=model,
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": prompt},
+                    {"type": "input_image", "image_url": image_url},
+                ],
+            }
+        ],
+    )
+    text = response.output_text.strip()
+    parts = [p.strip() for p in text.replace("\n", ",").split(",")]
+    return [p for p in parts if p]
+
+
+def tag_images(
+    gallery_root: str = "gallery",
+    ids: Optional[Iterable[str]] = None,
+    re_tag: bool = False,
+    remove: bool = False,
+    remove_ids: Optional[Iterable[str]] = None,
+    config_path: str = "tagging_config.json",
+    prompt: Optional[str] = None,
+    model: Optional[str] = None,
+) -> int:
+    meta_path = os.path.join(gallery_root, "metadata.json")
+    if not os.path.isfile(meta_path):
+        return 0
+    with open(meta_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    ids_set = set(ids) if ids else None
+    remove_ids_set = set(remove_ids) if remove_ids else None
+
+    updated = 0
+    if remove or remove_ids_set:
+        for item in data:
+            if remove or remove_ids_set and item.get("id") in remove_ids_set:
+                item["tags"] = []
+                updated += 1
+    else:
+        cfg = ensure_tagging_config(config_path)
+        client = OpenAI(api_key=cfg["api_key"])
+        use_prompt = prompt or cfg.get("prompt", DEFAULT_PROMPT)
+        use_model = model or cfg.get("model", "gpt-4.1-mini")
+        for item in data:
+            if ids_set and item.get("id") not in ids_set:
+                continue
+            if not ids_set and not re_tag and item.get("tags"):
+                continue
+            image_path = os.path.join(gallery_root, "images", item["filename"])
+            item["tags"] = generate_tags(image_path, client, use_model, use_prompt)
+            updated += 1
+
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    return updated
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Tag images with OpenAI")
+    parser.add_argument("--gallery", default="gallery")
+    parser.add_argument("--config", default="tagging_config.json")
+    parser.add_argument("--all", action="store_true", help="Re-tag all images")
+    parser.add_argument("--ids", nargs="+", help="Tag only specific image IDs")
+    parser.add_argument("--remove-all", action="store_true", help="Remove all tags")
+    parser.add_argument("--remove-ids", nargs="+", help="Remove tags for specific IDs")
+    parser.add_argument("--prompt", help="Override tagging prompt")
+    parser.add_argument("--model", help="Override model ID")
+    return parser.parse_args(argv)
+
+
+def main(args: Optional[argparse.Namespace] = None) -> int:
+    if args is None:
+        args = parse_args()
+    re_tag = args.all or bool(args.ids)
+    return tag_images(
+        gallery_root=args.gallery,
+        ids=args.ids,
+        re_tag=re_tag,
+        remove=args.remove_all,
+        remove_ids=args.remove_ids,
+        config_path=args.config,
+        prompt=args.prompt,
+        model=args.model,
+    )
+
+
+if __name__ == "__main__":
+    count = main()
+    print(f"Updated {count} images.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ def test_gallery_subcommand(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 
     # Ensure downloader is not invoked
-    def fail():  # pragma: no cover - should not be called
+    def fail(tag_new=False):  # pragma: no cover - should not be called
         raise AssertionError("incremental downloader should not run")
 
     monkeypatch.setattr(incremental_downloader, "main", fail)
@@ -63,3 +63,23 @@ def test_tag_subcommand(monkeypatch, tmp_path):
 
     assert "args" in called
     assert called["args"].remove_all is True
+
+
+def test_download_tag_new_flag(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    called = {}
+
+    def fake_main(tag_new=False):
+        called["tag_new"] = tag_new
+
+    monkeypatch.setattr(incremental_downloader, "main", fake_main)
+    monkeypatch.setattr(
+        sys, "argv", ["chatgpt_library_archiver", "download", "--tag-new"]
+    )
+    import importlib
+
+    cli = importlib.import_module("chatgpt_library_archiver.__main__")
+    cli.main()
+
+    assert called.get("tag_new") is True

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -1,0 +1,127 @@
+import json
+from pathlib import Path
+
+from chatgpt_library_archiver import tagger
+
+
+def _write_metadata(tmp_path: Path, items):
+    gallery = tmp_path / "gallery"
+    (gallery / "images").mkdir(parents=True)
+    with open(gallery / "metadata.json", "w", encoding="utf-8") as f:
+        json.dump(items, f)
+    for item in items:
+        (gallery / "images" / item["filename"]).write_text("img")
+    return gallery
+
+
+def test_tag_missing_only(monkeypatch, tmp_path):
+    gallery = _write_metadata(
+        tmp_path,
+        [
+            {"id": "1", "filename": "a.jpg", "tags": ["keep"]},
+            {"id": "2", "filename": "b.jpg", "tags": []},
+        ],
+    )
+
+    monkeypatch.setattr(
+        tagger,
+        "ensure_tagging_config",
+        lambda path="tagging_config.json": {
+            "api_key": "k",
+            "model": "m",
+            "prompt": "p",
+        },
+    )
+    monkeypatch.setattr(tagger, "generate_tags", lambda *a, **k: ["x", "y"])
+
+    count = tagger.tag_images(gallery_root=str(gallery))
+    assert count == 1
+    data = json.loads((gallery / "metadata.json").read_text())
+    assert data[0]["tags"] == ["keep"]
+    assert data[1]["tags"] == ["x", "y"]
+
+
+def test_retag_all(monkeypatch, tmp_path):
+    gallery = _write_metadata(
+        tmp_path,
+        [
+            {"id": "1", "filename": "a.jpg", "tags": ["old"]},
+            {"id": "2", "filename": "b.jpg", "tags": []},
+        ],
+    )
+
+    monkeypatch.setattr(
+        tagger,
+        "ensure_tagging_config",
+        lambda path="tagging_config.json": {
+            "api_key": "k",
+            "model": "m",
+            "prompt": "p",
+        },
+    )
+    monkeypatch.setattr(tagger, "generate_tags", lambda *a, **k: ["new"])
+
+    count = tagger.tag_images(gallery_root=str(gallery), re_tag=True)
+    assert count == 2
+    data = json.loads((gallery / "metadata.json").read_text())
+    assert data[0]["tags"] == ["new"]
+    assert data[1]["tags"] == ["new"]
+
+
+def test_tag_specific_ids(monkeypatch, tmp_path):
+    gallery = _write_metadata(
+        tmp_path,
+        [
+            {"id": "1", "filename": "a.jpg", "tags": []},
+            {"id": "2", "filename": "b.jpg", "tags": []},
+        ],
+    )
+
+    monkeypatch.setattr(
+        tagger,
+        "ensure_tagging_config",
+        lambda path="tagging_config.json": {
+            "api_key": "k",
+            "model": "m",
+            "prompt": "p",
+        },
+    )
+    monkeypatch.setattr(tagger, "generate_tags", lambda *a, **k: ["tagged"])
+
+    count = tagger.tag_images(gallery_root=str(gallery), ids=["2"])
+    assert count == 1
+    data = json.loads((gallery / "metadata.json").read_text())
+    assert data[0]["tags"] == []
+    assert data[1]["tags"] == ["tagged"]
+
+
+def test_remove_all_tags(tmp_path):
+    gallery = _write_metadata(
+        tmp_path,
+        [
+            {"id": "1", "filename": "a.jpg", "tags": ["a"]},
+            {"id": "2", "filename": "b.jpg", "tags": ["b"]},
+        ],
+    )
+
+    count = tagger.tag_images(gallery_root=str(gallery), remove=True)
+    assert count == 2
+    data = json.loads((gallery / "metadata.json").read_text())
+    assert data[0]["tags"] == []
+    assert data[1]["tags"] == []
+
+
+def test_remove_specific_ids(tmp_path):
+    gallery = _write_metadata(
+        tmp_path,
+        [
+            {"id": "1", "filename": "a.jpg", "tags": ["a"]},
+            {"id": "2", "filename": "b.jpg", "tags": ["b"]},
+        ],
+    )
+
+    count = tagger.tag_images(gallery_root=str(gallery), remove_ids=["1"])
+    assert count == 1
+    data = json.loads((gallery / "metadata.json").read_text())
+    assert data[0]["tags"] == []
+    assert data[1]["tags"] == ["b"]


### PR DESCRIPTION
## Summary
- add `tag` subcommand to populate or remove image tags via OpenAI
- implement `tagger` module with configurable API key, model, and prompt
- document new tagging workflow and configuration

## Testing
- `pre-commit run --files README.md pyproject.toml requirements-dev.txt requirements.txt src/chatgpt_library_archiver/__init__.py src/chatgpt_library_archiver/__main__.py src/chatgpt_library_archiver/tagger.py tests/test_cli.py tests/test_tagger.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c73de47fa4832fbd5d38b236fe7f35