### PR TITLE
feat: enhance image tagging with progress and usage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,14 +139,16 @@ python -m chatgpt_library_archiver tag [--all|--ids <id...>|--remove-all|--remov
 4. **Generate or manage image tags**
 
 ```bash
-python -m chatgpt_library_archiver tag [--gallery DIR] [--all|--ids <id...>|--remove-all|--remove-ids <id...>]
+python -m chatgpt_library_archiver tag [--gallery DIR] [--all|--ids <id...>|--remove-all|--remove-ids <id...>] [--workers N]
 ```
 - Populates the `tags` field in `metadata.json` using the OpenAI API. By
   default, only images missing tags are processed. Override the gallery location
   with `--gallery`. Use `--all` to re-tag every image, `--ids` to tag specific
   images, `--remove-all` to clear tags from all images, or `--remove-ids` to
   clear tags for specific images. The prompt and model can be overridden with
-  `--prompt` and `--model`.
+  `--prompt` and `--model`. The command reports progress as each image is
+  tagged and displays total token usage if provided by the API. It can run in
+  parallel with `--workers`.
 
 Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 

--- a/src/chatgpt_library_archiver/__main__.py
+++ b/src/chatgpt_library_archiver/__main__.py
@@ -75,6 +75,12 @@ def parse_args() -> argparse.Namespace:
         default="tagging_config.json",
         help="Path to OpenAI tagging configuration",
     )
+    tag.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="Number of parallel workers",
+    )
 
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
- remove `cost_per_image` config; derive token usage from API response
- report per-image tagging progress and total tokens without cost estimate
- document tagging workflow and usage reporting

## Testing
- `pre-commit run --files tests/test_tagger.py`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7484a5f80832fa325c00628d562cf