### PR TITLE
Handle ResponseUsage token counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ python -m chatgpt_library_archiver tag [--gallery DIR] [--all|--ids <id...>|--re
   images, `--remove-all` to clear tags from all images, or `--remove-ids` to
   clear tags for specific images. The prompt and model can be overridden with
   `--prompt` and `--model`. The command reports progress as each image is
-  tagged and displays total token usage if provided by the API. It can run in
-  parallel with `--workers`.
+  tagged and displays per-image and total token usage when the API includes a
+  `usage.total_tokens` field. It can run in parallel with `--workers`.
 
 Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 

--- a/src/chatgpt_library_archiver/tagger.py
+++ b/src/chatgpt_library_archiver/tagger.py
@@ -4,7 +4,7 @@ import json
 import mimetypes
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Iterable, List, Optional, Tuple
+from typing import Any, Iterable, List, Optional, Tuple
 
 from openai import OpenAI
 
@@ -50,7 +50,7 @@ def ensure_tagging_config(path: str = "tagging_config.json") -> dict:
 
 def generate_tags(
     image_path: str, client: OpenAI, model: str, prompt: str
-) -> Tuple[List[str], Optional[dict]]:
+) -> Tuple[List[str], Optional[Any]]:
     mime = mimetypes.guess_type(image_path)[0] or "image/jpeg"
     with open(image_path, "rb") as f:
         b64 = base64.b64encode(f.read()).decode("ascii")
@@ -123,7 +123,9 @@ def tag_images(
                 print(f"Uploading {item['filename']}...", flush=True)
                 tags, usage = generate_tags(image_path, client, use_model, use_prompt)
                 item["tags"] = tags
-                tokens = usage.get("total_tokens") if usage else None
+                tokens = (
+                    getattr(usage, "total_tokens", None) if usage is not None else None
+                )
                 if tokens is not None:
                     print(
                         f"Received tags for {item['id']} (tokens: {tokens})",

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 from chatgpt_library_archiver import tagger
 
@@ -148,7 +149,7 @@ def test_progress_and_tokens(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(
         tagger,
         "generate_tags",
-        lambda *a, **k: (["t"], {"total_tokens": 7}),
+        lambda *a, **k: (["t"], SimpleNamespace(total_tokens=7)),
     )
 
     count = tagger.tag_images(gallery_root=str(gallery), re_tag=True, max_workers=2)


### PR DESCRIPTION
## Summary
- handle OpenAI ResponseUsage objects when extracting token counts
- document token usage reporting and cover with tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c74ecaf3c4832fb57bb97d2bb8a96e