### PR TITLE
Add tag-based search with Boolean logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 - The `index.html` viewer is bundled with the tool and reused on each run.
 - `gallery/index.html` loads `metadata.json` via JavaScript and displays all images on one page.
 - Images are lazy-loaded using the Intersection Observer API so they're fetched only when they enter the viewport.
-- Use the search bar in the gallery to filter by title or a date range.
+- Use the search bar in the gallery to filter by title or tags with fuzzy matching
+  and Boolean expressions (AND/OR/NOT) or by a date range.
 - The gallery respects your system's light or dark preference, and the **Toggle Dark Mode** button lets you override it.
 - Click any thumbnail to open a full-screen viewer overlay. Navigate with the left/right
   arrow keys, press Escape to close, or follow the **Raw file** link to view the

--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -129,7 +129,8 @@ h1 { margin-bottom: 10px; }
     <input
       type="text"
       id="searchBox"
-      placeholder="Search by title..."
+      placeholder="Search title or tags (use AND/OR)"
+      title="Supports AND, OR, NOT and parentheses"
       oninput="filterGallery()"
     >
     <input type="date" id="startDate" onchange="filterGallery()">
@@ -162,6 +163,7 @@ async function loadImages() {
     card.dataset.title = title.toLowerCase();
     card.dataset.created = item.created_at ? String(item.created_at * 1000) : '';
     const tagsArr = item.tags || [];
+    card.dataset.tags = tagsArr.map(t => t.toLowerCase()).join('\n');
     const imgPath = 'images/' + item.filename;
     const created = item.created_at
       ? new Date(item.created_at * 1000)
@@ -222,16 +224,70 @@ function filterGallery() {
   const startMs = start ? new Date(start).getTime() : null;
   const endMs = end ? new Date(end).getTime() : null;
   const cards = document.querySelectorAll('.image-card');
+  const searchFn = text ? makeSearchFn(text) : () => true;
   cards.forEach(card => {
-    const title = card.dataset.title;
     const created = card.dataset.created ? parseInt(card.dataset.created) : null;
-    const matchesText = title.includes(text);
+    const matchesText = searchFn(card);
     const matchesStart = startMs === null || (created && created >= startMs);
     const matchesEnd = endMs === null || (created && created <= endMs);
     card.style.display =
       matchesText && matchesStart && matchesEnd ? '' : 'none';
   });
   updateVisibleIndices();
+}
+
+function tokenize(expr) {
+  const tokens = [];
+  const re = /\s*(\(|\)|AND|OR|NOT|[^()\s]+)\s*/gi;
+  let m;
+  while ((m = re.exec(expr)) !== null) {
+    tokens.push(m[1].toLowerCase());
+  }
+  return tokens;
+}
+
+function makeSearchFn(expr) {
+  const tokens = tokenize(expr);
+  let i = 0;
+  function parseExpr() {
+    let node = parseTerm();
+    while (tokens[i] === 'or') {
+      i++;
+      const rhs = parseTerm();
+      const lhs = node;
+      node = card => lhs(card) || rhs(card);
+    }
+    return node;
+  }
+  function parseTerm() {
+    let node = parseFactor();
+    while (tokens[i] === 'and') {
+      i++;
+      const rhs = parseFactor();
+      const lhs = node;
+      node = card => lhs(card) && rhs(card);
+    }
+    return node;
+  }
+  function parseFactor() {
+    const token = tokens[i++];
+    if (token === 'not') {
+      const fn = parseFactor();
+      return card => !fn(card);
+    }
+    if (token === '(') {
+      const fn = parseExpr();
+      if (tokens[i] === ')') i++;
+      return fn;
+    }
+    if (token && token !== ')' && token !== 'and' && token !== 'or') {
+      return card =>
+        (card.dataset.title && card.dataset.title.includes(token)) ||
+        (card.dataset.tags && card.dataset.tags.includes(token));
+    }
+    return () => true;
+  }
+  return parseExpr();
 }
 function changeSize() {
   const gallery = document.getElementById('gallery');

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -145,6 +145,38 @@ def test_filter_by_date_range():
     assert result.stdout.strip() == ",none"
 
 
+def test_filter_by_tags_boolean():
+    fn = _extract_filter_fn()
+    script = (
+        "function updateVisibleIndices(){}\n"
+        + fn
+        + textwrap.dedent(
+            """
+        const inputs = {
+          searchBox: { value: 'cat AND (black OR white)' },
+          startDate: { value: '' },
+          endDate: { value: '' },
+        };
+        const cards = [
+          { dataset: { title: 'img1', tags: 'blackcat\\npet' }, style: {} },
+          { dataset: { title: 'img2', tags: 'whitecat\\npet' }, style: {} },
+          { dataset: { title: 'img3', tags: 'graycat\\npet' }, style: {} },
+        ];
+        const document = {
+          getElementById: id => inputs[id],
+          querySelectorAll: () => cards,
+        };
+        filterGallery();
+        console.log(cards.map(c => c.style.display).join(','));
+        """
+        )
+    )
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, check=True
+    )
+    assert result.stdout.strip() == ",,none"
+
+
 def test_viewer_keyboard_navigation():
     script = textwrap.dedent(
         """


### PR DESCRIPTION
## Summary
- Add fuzzy tag search with AND/OR/NOT parsing to gallery filter
- Store normalized tags for each card and expose new search hints in UI
- Document tag search capabilities and test Boolean filtering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c753ff2fa8832fb66617e90095bdc9