### PR TITLE
Hide gallery metadata until hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 - Images are lazy-loaded using the Intersection Observer API so they're fetched only when they enter the viewport.
 - Use the search bar in the gallery to filter by title or tags with fuzzy matching
   and Boolean expressions (AND/OR/NOT) or by a date range.
+- Hover over a thumbnail to reveal its title, timestamp, tags, and conversation link;
+  the grid hides these details by default to keep the focus on the images.
 - The gallery respects your system's light or dark preference, and the **Toggle Dark Mode** button lets you override it.
 - Click any thumbnail to open a full-screen viewer overlay. Navigate with the left/right
   arrow keys, press Escape to close, or follow the **Raw file** link to view the

--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -41,14 +41,26 @@ body.dark {
 .gallery-medium { --thumb-size: 250px; }
 .gallery-large { --thumb-size: 400px; }
 .image-card {
-  border: 1px solid #ccc;
-  padding: 8px;
+  position: relative;
   border-radius: 8px;
-  font-size: 0.85em;
+  overflow: hidden;
   background: var(--card-bg);
 }
-img { width: 100%; border-radius: 4px; display: block; }
-.meta { margin-top: 6px; color: var(--meta-color); }
+.image-card img { width: 100%; display: block; }
+.meta {
+  display: none;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 0.85em;
+  padding: 6px;
+  box-sizing: border-box;
+}
+.image-card:hover .meta { display: block; }
+.meta a { color: #fff; text-decoration: underline; }
 h1 { margin-bottom: 10px; }
 .controls {
   display: flex;

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -36,6 +36,14 @@ def test_gallery_prefers_color_scheme():
     assert "@media (prefers-color-scheme: dark)" in html
 
 
+def test_gallery_hides_metadata_until_hover():
+    html = resources.read_text(
+        "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
+    )
+    assert ".meta {" in html and "display: none" in html
+    assert ".image-card:hover .meta" in html
+
+
 def test_gallery_uses_css_variables_and_layout():
     html = resources.read_text(
         "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"


### PR DESCRIPTION
## Summary
- Overlay image metadata and tags only on hover in gallery grid for a cleaner layout
- Document hover-to-reveal behavior in README
- Test that metadata is hidden by default and revealed on hover

## Testing
- `pre-commit run --files src/chatgpt_library_archiver/gallery_index.html README.md tests/test_gallery.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c75ff27460832f85ab84d8727802cd