### PR TITLE
Add sticky header to gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 - The `index.html` viewer is bundled with the tool and reused on each run.
 - `gallery/index.html` loads `metadata.json` via JavaScript and displays all images on one page.
 - Images are lazy-loaded using the Intersection Observer API so they're fetched only when they enter the viewport.
-- Use the search bar in the gallery to filter by title or tags with fuzzy matching
+- A sticky header keeps the page title, search filters, and settings visible while you browse.
+- Use the header's search filters to filter by title or tags with fuzzy matching
   and Boolean expressions (AND/OR/NOT) or by a date range.
 - Hover over a thumbnail to reveal its title, timestamp, tags, and conversation link;
   the grid hides these details by default to keep the focus on the images.

--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -16,7 +16,7 @@
 }
 body {
   font-family: sans-serif;
-  margin: var(--space);
+  margin: 0;
   background: var(--bg);
   color: var(--text);
   transition: background 0.3s, color 0.3s;
@@ -31,6 +31,7 @@ body.dark {
 .layout {
   max-width: var(--max-width);
   margin: 0 auto;
+  padding: 0 var(--space) var(--space);
 }
 .gallery-grid {
   display: grid;
@@ -61,12 +62,26 @@ body.dark {
 }
 .image-card:hover .meta { display: block; }
 .meta a { color: #fff; text-decoration: underline; }
-h1 { margin-bottom: 10px; }
+header.top-bar {
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  z-index: 100;
+  padding: 10px 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+header.top-bar h1 {
+  margin: 0;
+  font-size: 1.2em;
+}
 .controls {
   display: flex;
   justify-content: flex-end;
   gap: 10px;
-  margin-bottom: 15px;
+  margin: 0 0 0 auto;
 }
 .toggle, .size-select {
   background: var(--control-bg);
@@ -76,10 +91,13 @@ h1 { margin-bottom: 10px; }
   font-size: 0.9em;
 }
 .search-bar {
-  margin-bottom: 15px;
   display: flex;
   gap: 10px;
   align-items: center;
+}
+header.top-bar .search-bar {
+  flex: 1;
+  margin: 0;
 }
 .search-bar input {
   padding: 6px;
@@ -124,32 +142,34 @@ h1 { margin-bottom: 10px; }
 </style>
 </head>
 <body>
-<div class="layout">
-  <div class="controls">
-    <div class="size-select">
-      <strong>Select Image Size: </strong>
-      <select id="sizeSelector" onchange="changeSize()">
-        <option value="gallery-small">Small</option>
-        <option value="gallery-medium" selected>Medium</option>
-        <option value="gallery-large">Large</option>
-      </select>
-    </div>
-    <div class="toggle" onclick="toggleDarkMode()">Toggle Dark Mode</div>
+  <div class="layout">
+    <header class="top-bar">
+      <h1>Image Gallery</h1>
+      <div class="search-bar">
+        <input
+          type="text"
+          id="searchBox"
+          placeholder="Search title or tags (use AND/OR)"
+          title="Supports AND, OR, NOT and parentheses"
+          oninput="filterGallery()"
+        >
+        <input type="date" id="startDate" onchange="filterGallery()">
+        <input type="date" id="endDate" onchange="filterGallery()">
+      </div>
+      <div class="controls">
+        <div class="size-select">
+          <strong>Select Image Size: </strong>
+          <select id="sizeSelector" onchange="changeSize()">
+            <option value="gallery-small">Small</option>
+            <option value="gallery-medium" selected>Medium</option>
+            <option value="gallery-large">Large</option>
+          </select>
+        </div>
+        <div class="toggle" onclick="toggleDarkMode()">Toggle Dark Mode</div>
+      </div>
+    </header>
+    <div class="gallery-grid gallery-medium" id="gallery"></div>
   </div>
-  <h1>Image Gallery</h1>
-  <div class="search-bar">
-    <input
-      type="text"
-      id="searchBox"
-      placeholder="Search title or tags (use AND/OR)"
-      title="Supports AND, OR, NOT and parentheses"
-      oninput="filterGallery()"
-    >
-    <input type="date" id="startDate" onchange="filterGallery()">
-    <input type="date" id="endDate" onchange="filterGallery()">
-  </div>
-  <div class="gallery-grid gallery-medium" id="gallery"></div>
-</div>
 <div id="viewer">
   <img id="viewerImg" src="" alt="">
   <div class="viewer-meta"><a id="viewerRaw" href="" target="_blank">Raw file</a></div>

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -53,6 +53,14 @@ def test_gallery_uses_css_variables_and_layout():
     assert "--thumb-size" in html
 
 
+def test_gallery_has_sticky_header():
+    html = resources.read_text(
+        "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
+    )
+    assert '<header class="top-bar">' in html
+    assert "position: sticky" in html
+
+
 def test_generate_gallery_creates_single_index(tmp_path):
     gallery_root = tmp_path / "gallery"
     gallery_root.mkdir()


### PR DESCRIPTION
## Summary
- combine page title, search filters, and settings into a sticky header
- document new header behavior
- verify sticky header presence in gallery tests

## Testing
- `pre-commit run --files README.md src/chatgpt_library_archiver/gallery_index.html tests/test_gallery.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7637650a4832fb4e9e8116364c280