### PR TITLE
Expand gallery layout to full width and center thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 - `gallery/index.html` loads `metadata.json` via JavaScript and displays all images on one page.
 - Images are lazy-loaded using the Intersection Observer API so they're fetched only when they enter the viewport.
 - A sticky header keeps the page title, search filters, and settings visible while you browse.
+- The header and image grid span the full width of the viewport, and thumbnails are centered within their square cells.
 - Use the header's search filters to filter by title or tags with fuzzy matching
   and Boolean expressions (AND/OR/NOT) or by a date range.
 - Hover over a thumbnail to reveal its title, timestamp, tags, and conversation link;

--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -7,10 +7,8 @@
 :root {
   --space: 20px;
   --gap: 15px;
-  --max-width: 1200px;
   --bg: #fff;
   --text: #000;
-  --card-bg: #fff;
   --meta-color: #444;
   --control-bg: #ddd;
 }
@@ -24,19 +22,19 @@ body {
 body.dark {
   --bg: #111;
   --text: #eee;
-  --card-bg: #222;
   --meta-color: #ccc;
   --control-bg: #555;
 }
 .layout {
-  max-width: var(--max-width);
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   padding: 0 var(--space) var(--space);
 }
 .gallery-grid {
   display: grid;
   gap: var(--gap);
   grid-template-columns: repeat(auto-fill, minmax(var(--thumb-size, 200px), 1fr));
+  grid-auto-rows: var(--thumb-size, 200px);
 }
 .gallery-small { --thumb-size: 150px; }
 .gallery-medium { --thumb-size: 250px; }
@@ -45,9 +43,25 @@ body.dark {
   position: relative;
   border-radius: 8px;
   overflow: hidden;
-  background: var(--card-bg);
+  background: var(--bg);
+  height: 100%;
 }
-.image-card img { width: 100%; display: block; }
+.image-card a.thumb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+.image-card img {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  object-position: center;
+  display: block;
+}
 .meta {
   display: none;
   position: absolute;
@@ -67,7 +81,8 @@ header.top-bar {
   top: 0;
   background: var(--bg);
   z-index: 100;
-  padding: 10px 0;
+  padding: 10px var(--space);
+  width: 100%;
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
@@ -110,7 +125,6 @@ header.top-bar .search-bar {
   body:not(.light) {
     --bg: #111;
     --text: #eee;
-    --card-bg: #222;
     --meta-color: #ccc;
     --control-bg: #555;
   }
@@ -142,8 +156,7 @@ header.top-bar .search-bar {
 </style>
 </head>
 <body>
-  <div class="layout">
-    <header class="top-bar">
+  <header class="top-bar">
       <h1>Image Gallery</h1>
       <div class="search-bar">
         <input
@@ -167,7 +180,8 @@ header.top-bar .search-bar {
         </div>
         <div class="toggle" onclick="toggleDarkMode()">Toggle Dark Mode</div>
       </div>
-    </header>
+  </header>
+  <div class="layout">
     <div class="gallery-grid gallery-medium" id="gallery"></div>
   </div>
 <div id="viewer">

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -61,6 +61,17 @@ def test_gallery_has_sticky_header():
     assert "position: sticky" in html
 
 
+def test_gallery_grid_centers_images_and_is_full_width():
+    html = resources.read_text(
+        "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
+    )
+    assert "grid-auto-rows" in html
+    img_block = re.search(r"\.image-card img \{[^}]*\}", html)
+    assert img_block and "object-fit: contain" in img_block.group(0)
+    header_block = re.search(r"header.top-bar \{[^}]*\}", html)
+    assert header_block and "width: 100%" in header_block.group(0)
+
+
 def test_generate_gallery_creates_single_index(tmp_path):
     gallery_root = tmp_path / "gallery"
     gallery_root.mkdir()


### PR DESCRIPTION
## Summary
- Make gallery grid and header span the full viewport width
- Vertically center thumbnails and remove card background color
- Document full-width layout and add tests for grid and header styling

## Testing
- `pre-commit run --files README.md src/chatgpt_library_archiver/gallery_index.html tests/test_gallery.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c765f6ed78832f82d8f9e619845467