### PR TITLE
Limit gallery hover metadata height and truncate tags

### DIFF
--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -68,14 +68,22 @@ body.dark {
   bottom: 0;
   left: 0;
   width: 100%;
+  max-height: 50%;
   background: rgba(0, 0, 0, 0.6);
   color: #fff;
   font-size: 0.85em;
   padding: 6px;
   box-sizing: border-box;
+  overflow: hidden;
 }
 .image-card:hover .meta { display: block; }
 .meta a { color: #fff; text-decoration: underline; }
+.meta .tags {
+  font-size: 0.7em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 header.top-bar {
   position: sticky;
   top: 0;
@@ -217,13 +225,17 @@ async function loadImages() {
           .replace('T', ' ')
           .split('.')[0]
       : '';
-    const tags = tagsArr.join(', ') || '—';
+    const tagsSnippet = tagsArr.slice(0, 5).join(', ');
+    const extra = tagsArr.length > 5 ? '…' : '';
+    const tagsHtml =
+      tagsSnippet
+        ? '<br><span class="tags">' + tagsSnippet + extra + '</span>'
+        : '';
     card.innerHTML =
       '<a href="' + imgPath + '" class="thumb">' +
       '<img data-src="' + imgPath + '" alt="' + title + '" loading="lazy"></a>' +
       '<div class="meta"><strong>' + (title || item.id) + '</strong><br>' +
-      created + '<br>' +
-      'Tags: ' + tags + '<br><a href="' +
+      created + tagsHtml + '<br><a href="' +
       (item.conversation_link || '#') +
       '" target="_blank">View conversation</a></div>';
     const index = viewerData.push({ src: imgPath, title: title || item.id }) - 1;

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -44,6 +44,18 @@ def test_gallery_hides_metadata_until_hover():
     assert ".image-card:hover .meta" in html
 
 
+def test_gallery_limits_metadata_height_and_truncates_tags():
+    html = resources.read_text(
+        "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
+    )
+    meta_block = re.search(r"\.meta \{[^}]*\}", html)
+    assert meta_block and "max-height: 50%" in meta_block.group(0)
+    tags_block = re.search(r"\.meta \.tags \{[^}]*\}", html)
+    assert tags_block and "font-size: 0.7em" in tags_block.group(0)
+    assert "text-overflow: ellipsis" in tags_block.group(0)
+    assert "tagsArr.slice(0, 5)" in html
+
+
 def test_gallery_uses_css_variables_and_layout():
     html = resources.read_text(
         "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"


### PR DESCRIPTION
## Summary
- Prevent gallery hover metadata from covering images by capping overlay height and truncating tags.
- Style metadata tags with smaller font and ellipsis for long lists.
- Test gallery overlay constraints and tag truncation.

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c76d264828832f958a2052b4f97f44