### PR TITLE
fix: prevent gallery UI from overflowing viewport

### DIFF
--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -12,6 +12,9 @@
   --meta-color: #444;
   --control-bg: #ddd;
 }
+*, *::before, *::after {
+  box-sizing: border-box;
+}
 body {
   font-family: sans-serif;
   margin: 0;

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -84,6 +84,14 @@ def test_gallery_grid_centers_images_and_is_full_width():
     assert header_block and "width: 100%" in header_block.group(0)
 
 
+def test_gallery_uses_border_box_sizing():
+    html = resources.read_text(
+        "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
+    )
+    assert "*, *::before, *::after {" in html
+    assert "box-sizing: border-box" in html
+
+
 def test_generate_gallery_creates_single_index(tmp_path):
     gallery_root = tmp_path / "gallery"
     gallery_root.mkdir()


### PR DESCRIPTION
## Summary
- apply global `border-box` sizing to gallery HTML to keep header and layout within viewport
- test for global box-sizing rule in gallery template

## Testing
- `python -m pre_commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7756b235c832fac791d593a2023be