### PR TITLE
Show full tags in tooltip on card overlay

### DIFF
--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -241,6 +241,10 @@ async function loadImages() {
       created + tagsHtml + '<br><a href="' +
       (item.conversation_link || '#') +
       '" target="_blank">View conversation</a></div>';
+    const tagsSpan = card.querySelector('.tags');
+    if (tagsSpan) {
+      tagsSpan.title = tagsArr.join(', ');
+    }
     const index = viewerData.push({ src: imgPath, title: title || item.id }) - 1;
     card.dataset.index = String(index);
     gallery.appendChild(card);


### PR DESCRIPTION
## Summary
- display complete tag list in native tooltip when hovering truncated tags on gallery cards

## Testing
- `pre-commit run --files src/chatgpt_library_archiver/gallery_index.html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c77a9753a8832f978b6743aef078ad