### PR TITLE
Persist gallery theme and filter settings in session

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 - Hover over a thumbnail to reveal its title, timestamp, tags, and conversation link;
   the grid hides these details by default to keep the focus on the images.
 - The gallery respects your system's light or dark preference, and the **Toggle Dark Mode** button lets you override it.
+- Your selected theme, image size, and filter values are remembered for the current browser session.
 - Click any thumbnail to open a full-screen viewer overlay. Navigate with the left/right
   arrow keys, press Escape to close, or follow the **Raw file** link to view the
   underlying image. Ctrl-click (Cmd-click on macOS) a thumbnail to open the raw image

--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -269,23 +269,46 @@ function toggleDarkMode() {
   if (isDark) {
     document.body.classList.remove('dark');
     document.body.classList.add('light');
-    localStorage.setItem('theme', 'light');
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem('theme', 'light');
+    }
   } else {
     document.body.classList.remove('light');
     document.body.classList.add('dark');
-    localStorage.setItem('theme', 'dark');
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem('theme', 'dark');
+    }
   }
 }
-const savedTheme = localStorage.getItem('theme');
+const savedTheme = sessionStorage.getItem('theme');
 if (savedTheme === 'dark') {
   document.body.classList.add('dark');
 } else if (savedTheme === 'light') {
   document.body.classList.add('light');
 }
+const savedSize = sessionStorage.getItem('size');
+if (savedSize) {
+  document.getElementById('sizeSelector').value = savedSize;
+  document.getElementById('gallery').className = 'gallery-grid ' + savedSize;
+}
+const savedText = sessionStorage.getItem('filter-text') || '';
+const savedStart = sessionStorage.getItem('filter-start') || '';
+const savedEnd = sessionStorage.getItem('filter-end') || '';
+document.getElementById('searchBox').value = savedText;
+document.getElementById('startDate').value = savedStart;
+document.getElementById('endDate').value = savedEnd;
 function filterGallery() {
-  const text = document.getElementById('searchBox').value.toLowerCase();
-  const start = document.getElementById('startDate').value;
-  const end = document.getElementById('endDate').value;
+  const textEl = document.getElementById('searchBox');
+  const startEl = document.getElementById('startDate');
+  const endEl = document.getElementById('endDate');
+  const text = textEl.value.toLowerCase();
+  const start = startEl.value;
+  const end = endEl.value;
+  if (typeof sessionStorage !== 'undefined') {
+    sessionStorage.setItem('filter-text', textEl.value);
+    sessionStorage.setItem('filter-start', start);
+    sessionStorage.setItem('filter-end', end);
+  }
   const startMs = start ? new Date(start).getTime() : null;
   const endMs = end ? new Date(end).getTime() : null;
   const cards = document.querySelectorAll('.image-card');
@@ -356,8 +379,11 @@ function makeSearchFn(expr) {
 }
 function changeSize() {
   const gallery = document.getElementById('gallery');
-  gallery.className = 'gallery-grid ' +
-    document.getElementById('sizeSelector').value;
+  const size = document.getElementById('sizeSelector').value;
+  gallery.className = 'gallery-grid ' + size;
+  if (typeof sessionStorage !== 'undefined') {
+    sessionStorage.setItem('size', size);
+  }
 }
 let viewerData = [];
 let visibleIndices = [];
@@ -409,6 +435,6 @@ document.addEventListener('keydown', e => {
     showNext(-1);
   }
 });
-loadImages();
+loadImages().then(filterGallery);
 </script>
 </body></html>

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -92,6 +92,18 @@ def test_gallery_uses_border_box_sizing():
     assert "box-sizing: border-box" in html
 
 
+def test_gallery_persists_theme_size_and_filter():
+    html = resources.read_text(
+        "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
+    )
+    assert "sessionStorage.setItem('size'" in html
+    assert "sessionStorage.getItem('size')" in html
+    assert "sessionStorage.setItem('theme'" in html
+    assert "sessionStorage.getItem('theme')" in html
+    assert "sessionStorage.setItem('filter-text'" in html
+    assert "sessionStorage.getItem('filter-text')" in html
+
+
 def test_generate_gallery_creates_single_index(tmp_path):
     gallery_root = tmp_path / "gallery"
     gallery_root.mkdir()
@@ -138,7 +150,7 @@ def _extract_viewer_script() -> str:
         "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
     )
     start = html.index("let viewerData")
-    end = html.index("loadImages();")
+    end = html.index("loadImages().then(filterGallery);")
     return html[start:end]
 
 


### PR DESCRIPTION
## Summary
- save selected theme, image size, and filter values in session storage and restore them on load
- document session persistence for theme, size, and filters
- test that gallery HTML uses session storage for theme, size, and filter

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c77ae09694832f837bdb1a69dff5ff