### PR TITLE
Hide metadata on small gallery cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 - Use the header's search filters to filter by title or tags with fuzzy matching
   and Boolean expressions (AND/OR/NOT) or by a date range.
 - Hover over a thumbnail to reveal its title, timestamp, tags, and conversation link;
-  the grid hides these details by default to keep the focus on the images.
+  the grid hides these details by default to keep the focus on the images. Small
+  thumbnails omit the timestamp and tags to keep overlays compact.
 - The gallery respects your system's light or dark preference, and the **Toggle Dark Mode** button lets you override it.
 - Click any thumbnail to open a full-screen viewer overlay. Navigate with the left/right
   arrow keys, press Escape to close, or follow the **Raw file** link to view the

--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -42,6 +42,8 @@ body.dark {
 .gallery-small { --thumb-size: 150px; }
 .gallery-medium { --thumb-size: 250px; }
 .gallery-large { --thumb-size: 400px; }
+.gallery-small .meta .created,
+.gallery-small .meta .tags { display: none; }
 .image-card {
   position: relative;
   border-radius: 8px;
@@ -232,13 +234,14 @@ async function loadImages() {
     const extra = tagsArr.length > 5 ? '…' : '';
     const tagsHtml =
       tagsSnippet
-        ? '<br><span class="tags">' + tagsSnippet + extra + '</span>'
+        ? '<span class="tags"><br>' + tagsSnippet + extra + '</span>'
         : '';
     card.innerHTML =
       '<a href="' + imgPath + '" class="thumb">' +
       '<img data-src="' + imgPath + '" alt="' + title + '" loading="lazy"></a>' +
-      '<div class="meta"><strong>' + (title || item.id) + '</strong><br>' +
-      created + tagsHtml + '<br><a href="' +
+      '<div class="meta"><strong>' + (title || item.id) + '</strong>' +
+      '<span class="created"><br>' + created + '</span>' +
+      tagsHtml + '<br><a href="' +
       (item.conversation_link || '#') +
       '" target="_blank">View conversation</a></div>';
     const tagsSpan = card.querySelector('.tags');

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -44,15 +44,30 @@ def test_gallery_hides_metadata_until_hover():
     assert ".image-card:hover .meta" in html
 
 
+def test_small_gallery_hides_date_and_tags():
+    html = resources.read_text(
+        "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
+    )
+    assert '<span class="created"><br>' in html
+    assert '<span class="tags"><br>' in html
+    css = re.search(
+        r"\.gallery-small \.meta \.created,\s*\.gallery-small \.meta \.tags \{[^}]*\}",
+        html,
+    )
+    assert css and "display: none" in css.group(0)
+
+
 def test_gallery_limits_metadata_height_and_truncates_tags():
     html = resources.read_text(
         "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
     )
     meta_block = re.search(r"\.meta \{[^}]*\}", html)
     assert meta_block and "max-height: 50%" in meta_block.group(0)
-    tags_block = re.search(r"\.meta \.tags \{[^}]*\}", html)
-    assert tags_block and "font-size: 0.7em" in tags_block.group(0)
-    assert "text-overflow: ellipsis" in tags_block.group(0)
+    tags_blocks = re.findall(r"\.meta \.tags \{[^}]*\}", html)
+    assert any(
+        "font-size: 0.7em" in block and "text-overflow: ellipsis" in block
+        for block in tags_blocks
+    )
     assert "tagsArr.slice(0, 5)" in html
 
 


### PR DESCRIPTION
## Summary
- ensure small gallery cards hide date and tags to prevent overlay overflow
- document and test small-card overlay behavior

## Testing
- `pre-commit run --files README.md src/chatgpt_library_archiver/gallery_index.html tests/test_gallery.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c77c59be4c832f923c74a9e2e7b75d