### PR TITLE
Simplify search placeholder and add syntax tooltip

### DIFF
--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -141,6 +141,18 @@ header.top-bar .search-bar {
   padding: 6px;
   cursor: pointer;
 }
+.search-bar .help-icon {
+  background: var(--control-bg);
+  border-radius: 50%;
+  cursor: help;
+  display: inline-block;
+  font-size: 0.8em;
+  font-weight: bold;
+  height: 20px;
+  line-height: 20px;
+  text-align: center;
+  width: 20px;
+}
 .date-range {
   display: flex;
   gap: 5px;
@@ -208,10 +220,16 @@ header.top-bar .search-bar {
         <input
           type="text"
           id="searchBox"
-          placeholder="Search title or tags (use AND/OR)"
-          title="Supports AND, OR, NOT and parentheses"
+          placeholder="Search images"
+          aria-describedby="searchHelp"
           oninput="filterGallery()"
         >
+        <span
+          id="searchHelp"
+          class="help-icon"
+          tabindex="0"
+          title="Use AND, OR, NOT, and parentheses to refine search."
+        >?</span>
         <div class="date-range">
           <span>Date range:</span>
           <input type="date" id="startDate" aria-label="Start date" onchange="filterGallery()">

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -97,6 +97,15 @@ def test_gallery_has_reset_and_github_link():
     assert 'href="https://github.com/kabaka/chatgpt-library-archiver"' in html
 
 
+def test_gallery_has_search_help_tooltip():
+    html = resources.read_text(
+        "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"
+    )
+    assert 'placeholder="Search images"' in html
+    assert 'id="searchHelp"' in html
+    assert "Use AND, OR, NOT, and parentheses to refine search" in html
+
+
 def test_gallery_grid_centers_images_and_is_full_width():
     html = resources.read_text(
         "chatgpt_library_archiver", "gallery_index.html", encoding="utf-8"


### PR DESCRIPTION
## Summary
- shorten gallery search placeholder text
- add nearby tooltip explaining Boolean search syntax
- keep README search filter instructions concise
- add regression test for placeholder and tooltip

## Testing
- `pre-commit run --files README.md`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7a2ec3f80832fbc4113a7ecc48dde