### PR TITLE
feat: add CLI importer for local images

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ can create it manually with contents like:
 {
   "api_key": "sk-...",
   "model": "gpt-4.1-mini",
-  "prompt": "Generate concise, comma-separated tags describing this image."
+  "prompt": "Generate concise, comma-separated tags describing this image.",
+  "rename_prompt": "Create a short, descriptive filename slug (kebab-case) for this image."
 }
 ```
 
@@ -140,6 +141,21 @@ python -m chatgpt_library_archiver tag [--gallery DIR] [--all|--ids <id...>|--re
   `--prompt` and `--model`. The command reports progress as each image is
   tagged and displays per-image and total token usage when the API includes a
   `usage.total_tokens` field. It can run in parallel with `--workers`.
+
+5. **Import local images into your gallery**
+
+```bash
+python -m chatgpt_library_archiver import <files_or_directories...> [options]
+```
+
+- Move local files into `gallery/images` and append metadata records.
+- Provide `--copy` to copy instead of move (default is move).
+- Use `--recursive` when passing directories to automatically traverse and import nested images.
+- Apply one or more tags to all imported items with repeated `--tag` flags.
+- Supply `--conversation-link` to attach a ChatGPT conversation URL for each file listed explicitly on the command line (directory imports skip this as they may expand to many files).
+- Pass `--tag-new` to immediately tag imports using the existing OpenAI tagging workflow (honors `--tag-model`, `--tag-prompt`, and `--tag-workers`).
+- Enable `--ai-rename` to request a descriptive filename from OpenAI. The `tagging_config.json` file supplies the API key and optionally a `rename_prompt` value for this feature. Provide `--rename-model` or `--rename-prompt` to override the defaults ad hoc.
+- Set a shared `--title` for all imported files or allow the tool to derive one from the filename/AI slug.
 
 Use the `-y/--yes` flag with any command to bypass confirmation prompts.
 

--- a/src/chatgpt_library_archiver/__init__.py
+++ b/src/chatgpt_library_archiver/__init__.py
@@ -1,5 +1,12 @@
 """Top-level package for ChatGPT Library Archiver."""
 
-__all__ = ["bootstrap", "incremental_downloader", "gallery", "tagger", "utils"]
+__all__ = [
+    "bootstrap",
+    "incremental_downloader",
+    "gallery",
+    "tagger",
+    "utils",
+    "importer",
+]
 
 __version__ = "0.1.0"

--- a/src/chatgpt_library_archiver/importer.py
+++ b/src/chatgpt_library_archiver/importer.py
@@ -1,0 +1,354 @@
+"""Utilities for importing arbitrary images into the gallery."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import mimetypes
+import re
+import shutil
+import unicodedata
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from openai import OpenAI
+
+from . import gallery, tagger
+from .utils import prompt_yes_no
+
+
+IMAGE_EXTENSIONS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".webp",
+    ".bmp",
+    ".tiff",
+    ".tif",
+}
+
+DEFAULT_RENAME_PROMPT = (
+    "Create a short, descriptive filename slug (kebab-case, <=6 words) for this image."
+)
+
+
+@dataclass
+class ImportItem:
+    """Represents a single image scheduled for import."""
+
+    source: Path
+    conversation_link: Optional[str] = None
+
+
+def _is_image_file(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    ext = path.suffix.lower()
+    if ext in IMAGE_EXTENSIONS:
+        return True
+    mime, _ = mimetypes.guess_type(path)
+    return bool(mime and mime.startswith("image/"))
+
+
+def _slugify(text: str, fallback: str = "image") -> str:
+    normalized = unicodedata.normalize("NFKD", text)
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
+    ascii_text = ascii_text.lower()
+    ascii_text = re.sub(r"[^a-z0-9]+", "-", ascii_text).strip("-")
+    return ascii_text or fallback
+
+
+def _unique_filename(base: str, ext: str, existing: set[str]) -> str:
+    candidate = f"{base}{ext}"
+    counter = 2
+    while candidate in existing:
+        candidate = f"{base}-{counter}{ext}"
+        counter += 1
+    existing.add(candidate)
+    return candidate
+
+
+def _load_metadata(path: Path) -> List[dict]:
+    if path.is_file():
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    return []
+
+
+def _write_metadata(path: Path, data: List[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+
+
+def _collect_inputs(
+    inputs: Sequence[str], recursive: bool
+) -> Tuple[List[ImportItem], List[Path]]:
+    items: List[ImportItem] = []
+    original_files: List[Path] = []
+    for raw in inputs:
+        path = Path(raw)
+        if not path.exists():
+            raise FileNotFoundError(f"Input path not found: {path}")
+        if path.is_file():
+            items.append(ImportItem(source=path))
+            original_files.append(path)
+            continue
+        if not recursive:
+            raise ValueError(
+                f"Directory '{path}' provided but --recursive flag not set."
+            )
+        for child in sorted(path.rglob("*")):
+            if _is_image_file(child):
+                items.append(ImportItem(source=child))
+    return items, original_files
+
+
+def _prepare_ai_client(
+    *, config_path: str, model: Optional[str]
+) -> Tuple[OpenAI, str, str]:
+    cfg = tagger.ensure_tagging_config(config_path)
+    client = OpenAI(api_key=cfg["api_key"])
+    use_model = model or cfg.get("model", "gpt-4.1-mini")
+    rename_prompt = cfg.get("rename_prompt", DEFAULT_RENAME_PROMPT)
+    return client, use_model, rename_prompt
+
+
+def _generate_ai_slug(
+    client: OpenAI, model: str, prompt: str, image_path: Path
+) -> Optional[str]:
+    mime = mimetypes.guess_type(str(image_path))[0] or "image/jpeg"
+    with open(image_path, "rb") as fh:
+        payload = base64.b64encode(fh.read()).decode("ascii")
+    image_url = f"data:{mime};base64,{payload}"
+    response = client.responses.create(
+        model=model,
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": prompt},
+                    {"type": "input_image", "image_url": image_url},
+                ],
+            }
+        ],
+    )
+    text = response.output_text.strip()
+    slug = _slugify(text)
+    return slug or None
+
+
+def import_images(
+    *,
+    inputs: Sequence[str],
+    gallery_root: str = "gallery",
+    copy_files: bool = False,
+    recursive: bool = False,
+    tags: Optional[Iterable[str]] = None,
+    title: Optional[str] = None,
+    conversation_links: Optional[Sequence[str]] = None,
+    tag_new: bool = False,
+    config_path: str = "tagging_config.json",
+    ai_rename: bool = False,
+    rename_model: Optional[str] = None,
+    rename_prompt: Optional[str] = None,
+    tag_prompt: Optional[str] = None,
+    tag_model: Optional[str] = None,
+    tag_workers: int = 4,
+) -> List[dict]:
+    if not inputs:
+        raise ValueError("No inputs supplied for import.")
+
+    items, direct_files = _collect_inputs(inputs, recursive)
+
+    if not items:
+        raise ValueError("No importable images were found.")
+
+    if conversation_links:
+        if len(conversation_links) != len(direct_files):
+            raise ValueError(
+                "Number of --conversation-link values must match direct file inputs."
+            )
+        link_map = {path: link for path, link in zip(direct_files, conversation_links)}
+        for item in items:
+            if item.source in link_map:
+                item.conversation_link = link_map[item.source]
+
+    gallery_path = Path(gallery_root)
+    images_dir = gallery_path / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+    metadata_path = gallery_path / "metadata.json"
+
+    data = _load_metadata(metadata_path)
+    existing_files = {entry.get("filename", "") for entry in data}
+    existing_files.discard("")
+
+    tags_list: List[str] = []
+    if tags:
+        for tag in tags:
+            parts = [p.strip() for p in tag.split(",")]
+            tags_list.extend([p for p in parts if p])
+
+    if not prompt_yes_no(
+        f"Import {len(items)} image(s) into {gallery_path}?", default=True
+    ):
+        return []
+
+    ai_client: Optional[OpenAI] = None
+    ai_model: Optional[str] = None
+    ai_prompt: Optional[str] = None
+    if ai_rename:
+        ai_client, ai_model, cfg_prompt = _prepare_ai_client(
+            config_path=config_path, model=rename_model
+        )
+        ai_prompt = rename_prompt or cfg_prompt
+
+    imported: List[dict] = []
+
+    for item in items:
+        source_path = item.source
+        if not _is_image_file(source_path):
+            continue
+
+        slug: Optional[str] = None
+        if ai_client is not None:
+            try:
+                slug = _generate_ai_slug(ai_client, ai_model, ai_prompt or DEFAULT_RENAME_PROMPT, source_path)
+            except Exception:
+                slug = None
+
+        if not slug:
+            slug = _slugify(source_path.stem)
+
+        ext = source_path.suffix.lower() or ".jpg"
+        filename = _unique_filename(slug, ext, existing_files)
+        dest = images_dir / filename
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if copy_files:
+            shutil.copy2(source_path, dest)
+        else:
+            shutil.move(source_path, dest)
+
+        created_at = datetime.now(timezone.utc).isoformat()
+        record = {
+            "id": uuid.uuid4().hex,
+            "filename": filename,
+            "title": title or slug.replace("-", " ").title(),
+            "prompt": None,
+            "tags": list(tags_list),
+            "created_at": created_at,
+            "width": None,
+            "height": None,
+            "url": None,
+            "conversation_id": None,
+            "message_id": None,
+            "conversation_link": item.conversation_link,
+        }
+        data.append(record)
+        imported.append(record)
+
+    _write_metadata(metadata_path, data)
+
+    if imported:
+        if tag_new:
+            ids = [entry["id"] for entry in imported]
+            tagger.tag_images(
+                gallery_root=str(gallery_path),
+                ids=ids,
+                config_path=config_path,
+                prompt=tag_prompt,
+                model=tag_model,
+                max_workers=tag_workers,
+            )
+        gallery.generate_gallery(gallery_root=str(gallery_path))
+
+    return imported
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Import images into the gallery")
+    parser.add_argument("inputs", nargs="+", help="Files or directories to import")
+    parser.add_argument("--gallery", default="gallery", help="Gallery root path")
+    parser.add_argument(
+        "--copy",
+        action="store_true",
+        help="Copy files instead of moving them",
+    )
+    parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recurse into directories when importing",
+    )
+    parser.add_argument(
+        "--tag",
+        dest="tags",
+        action="append",
+        default=[],
+        help="Add tag(s) to imported images. Can be repeated or comma-separated.",
+    )
+    parser.add_argument("--title", help="Override title for all imported images")
+    parser.add_argument(
+        "--conversation-link",
+        dest="conversation_links",
+        action="append",
+        help="Conversation link for corresponding direct file inputs.",
+    )
+    parser.add_argument(
+        "--tag-new",
+        action="store_true",
+        help="Tag imported images using OpenAI",
+    )
+    parser.add_argument(
+        "--config",
+        default="tagging_config.json",
+        help="Path to tagging/AI configuration",
+    )
+    parser.add_argument(
+        "--ai-rename",
+        action="store_true",
+        help="Use OpenAI to generate descriptive filenames",
+    )
+    parser.add_argument("--rename-model", help="Model to use for AI renaming")
+    parser.add_argument("--rename-prompt", help="Prompt override for AI renaming")
+    parser.add_argument("--tag-prompt", help="Prompt override for tagging imported images")
+    parser.add_argument("--tag-model", help="Model override for tagging imported images")
+    parser.add_argument(
+        "--tag-workers",
+        type=int,
+        default=4,
+        help="Parallel workers when tagging imported images",
+    )
+    return parser.parse_args(argv)
+
+
+def main(args: Optional[argparse.Namespace] = None) -> int:
+    if args is None:
+        args = parse_args()
+    imported = import_images(
+        inputs=args.inputs,
+        gallery_root=args.gallery,
+        copy_files=args.copy,
+        recursive=args.recursive,
+        tags=args.tags,
+        title=args.title,
+        conversation_links=args.conversation_links,
+        tag_new=args.tag_new,
+        config_path=args.config,
+        ai_rename=args.ai_rename,
+        rename_model=args.rename_model,
+        rename_prompt=args.rename_prompt,
+        tag_prompt=args.tag_prompt,
+        tag_model=args.tag_model,
+        tag_workers=args.tag_workers,
+    )
+    return len(imported)
+
+
+if __name__ == "__main__":
+    count = main()
+    print(f"Imported {count} images.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import json
 import sys
 from pathlib import Path
 
-from chatgpt_library_archiver import incremental_downloader, tagger
+from chatgpt_library_archiver import importer, incremental_downloader, tagger
 
 
 def test_gallery_subcommand(monkeypatch, tmp_path):
@@ -84,3 +84,36 @@ def test_download_tag_new_flag(monkeypatch, tmp_path):
     cli.main()
 
     assert called.get("tag_new") is True
+
+
+def test_import_subcommand(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    called = {}
+
+    def fake_import_images(**kwargs):
+        called.update(kwargs)
+        return [{"id": "abc"}]
+
+    monkeypatch.setattr(importer, "import_images", fake_import_images)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "chatgpt_library_archiver",
+            "import",
+            "example.png",
+            "--copy",
+            "--tag",
+            "demo",
+        ],
+    )
+
+    import importlib
+
+    cli = importlib.import_module("chatgpt_library_archiver.__main__")
+    cli.main()
+
+    assert called["inputs"] == ["example.png"]
+    assert called["copy_files"] is True
+    assert called["tags"] == ["demo"]

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,109 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from chatgpt_library_archiver import importer
+
+
+def always_yes(*_args, **_kwargs):
+    return True
+
+
+def test_import_single_file_move(monkeypatch, tmp_path):
+    monkeypatch.setattr(importer, "prompt_yes_no", always_yes)
+
+    src = tmp_path / "sample.png"
+    src.write_bytes(b"image-bytes")
+
+    gallery_root = tmp_path / "gallery"
+
+    imported = importer.import_images(
+        inputs=[str(src)],
+        gallery_root=str(gallery_root),
+        tags=["tag1", "tag2"],
+        conversation_links=["https://chat.openai.com/c/abc#def"],
+    )
+
+    assert len(imported) == 1
+    assert not src.exists()
+
+    dest = gallery_root / "images" / imported[0]["filename"]
+    assert dest.exists()
+    assert dest.read_bytes() == b"image-bytes"
+
+    metadata = json.loads((gallery_root / "metadata.json").read_text())
+    assert metadata[0]["tags"] == ["tag1", "tag2"]
+    assert metadata[0]["conversation_link"] == "https://chat.openai.com/c/abc#def"
+
+
+def test_import_copy_keeps_source(monkeypatch, tmp_path):
+    monkeypatch.setattr(importer, "prompt_yes_no", always_yes)
+
+    src = tmp_path / "copyme.jpg"
+    src.write_bytes(b"data")
+
+    gallery_root = tmp_path / "gallery"
+
+    importer.import_images(
+        inputs=[str(src)],
+        gallery_root=str(gallery_root),
+        copy_files=True,
+    )
+
+    assert src.exists()
+    metadata = json.loads((gallery_root / "metadata.json").read_text())
+    assert len(metadata) == 1
+
+
+def test_recursive_directory_import(monkeypatch, tmp_path):
+    monkeypatch.setattr(importer, "prompt_yes_no", always_yes)
+
+    gallery_root = tmp_path / "gallery"
+    gallery_root.mkdir()
+    images_dir = gallery_root / "images"
+    images_dir.mkdir()
+    existing = {
+        "id": "existing",
+        "filename": "existing.png",
+        "created_at": "earlier",
+    }
+    (gallery_root / "metadata.json").write_text(json.dumps([existing]))
+
+    folder = tmp_path / "folder"
+    (folder / "nested").mkdir(parents=True)
+    (folder / "nested" / "one.png").write_bytes(b"1")
+    (folder / "nested" / "two.PNG").write_bytes(b"2")
+    (folder / "nested" / "notes.txt").write_text("ignore")
+
+    imported = importer.import_images(
+        inputs=[str(folder)],
+        gallery_root=str(gallery_root),
+        recursive=True,
+        tags=["folder"],
+    )
+
+    # two png images imported, txt ignored
+    assert len(imported) == 2
+
+    metadata = json.loads((gallery_root / "metadata.json").read_text())
+    assert len(metadata) == 3
+    assert metadata[-1]["tags"] == ["folder"]
+    filenames = {entry["filename"] for entry in metadata}
+    assert any(name.endswith(".png") for name in filenames if name != "existing.png")
+
+
+def test_conversation_link_count_mismatch(monkeypatch, tmp_path):
+    monkeypatch.setattr(importer, "prompt_yes_no", always_yes)
+
+    f1 = tmp_path / "a.jpg"
+    f2 = tmp_path / "b.jpg"
+    f1.write_bytes(b"a")
+    f2.write_bytes(b"b")
+
+    with pytest.raises(ValueError):
+        importer.import_images(
+            inputs=[str(f1), str(f2)],
+            gallery_root=str(tmp_path / "gallery"),
+            conversation_links=["only-one"],
+        )


### PR DESCRIPTION
## Summary
- add a dedicated importer module that can move/copy local images into the gallery, add metadata, tag them, and optionally rename files via OpenAI
- expose the importer through a new `import` CLI subcommand and document its usage alongside updates to `tagging_config.json`
- cover the importer and CLI plumbing with new tests for imports, recursion, and conversation link validation

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d87564f0e8832f99ee388c2fd9f8d0