### PR TITLE
Fix gallery timestamp normalization

### DIFF
--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -198,6 +198,7 @@ def test_generate_gallery_handles_mixed_created_at_types(tmp_path):
         sorted_data = json.load(f)
 
     assert [item["id"] for item in sorted_data] == ["recent", "old", "invalid"]
+    assert all(isinstance(item["created_at"], float) for item in sorted_data)
 
 
 def _extract_filter_fn() -> str:


### PR DESCRIPTION
## Summary
- normalize mixed gallery created_at values to floats when regenerating metadata
- reuse the normalization for sorting to keep ordering behavior consistent
- extend gallery test coverage to ensure timestamps are stored as floats

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db22617e14832f9e90da14174c9c39