### PR TITLE
test: verify console script via built wheel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Instructions
+
+- Before committing changes in this repository, run `pre-commit run --all-files` and address any issues it reports.


### PR DESCRIPTION
## Summary
- add a CLI integration test that builds the wheel into a temp directory, installs it in an isolated venv, and exercises `chatgpt-archiver --help`
- skip the wheel-based CLI test when running on non-CPython interpreters or when the `build` module is unavailable

## Testing
- PYTHONPATH=src pytest tests/test_cli.py -k built_wheel -q


------
https://chatgpt.com/codex/tasks/task_e_68db5ad7f534832fb14c7682a9966e06