### PR TITLE
feat: add responsive gallery thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ your images with this version or run a previous release to migrate your data.
 gallery/
 ├── images/
 ├── thumbs/
+│   ├── small/
+│   ├── medium/
+│   └── large/
 ├── metadata.json
 └── index.html  ← single-page gallery
 auth.txt        ← credentials for API access
@@ -126,7 +129,7 @@ it so you can monitor each stage of the workflow without losing context.
 ```bash
 python -m chatgpt_library_archiver [--tag-new]
 ```
-- Downloads **only new images**, adds them to `gallery/images`, updates `gallery/metadata.json`, creates `gallery/thumbs/<file>` thumbnails, and regenerates `gallery/index.html`
+- Downloads **only new images**, adds them to `gallery/images`, updates `gallery/metadata.json`, creates `gallery/thumbs/<size>/<file>` thumbnails, and regenerates `gallery/index.html`
 - Add `--tag-new` to tag fresh images during the download
 
 3. **Regenerate gallery or thumbnails without downloading**
@@ -136,7 +139,7 @@ python -m chatgpt_library_archiver [--tag-new]
  ```
  - Rebuilds the HTML gallery from existing files (sorts metadata and copies the
   bundled `index.html`).
- - Add `--regenerate-thumbnails` to (re)create entries in `gallery/thumbs/` for every
+ - Add `--regenerate-thumbnails` to (re)create entries in `gallery/thumbs/<size>/` for every
   image; combine with `--force-thumbnails` to overwrite existing thumbnails.
 
 4. **Generate or manage image tags**
@@ -167,7 +170,7 @@ python -m chatgpt_library_archiver import <files_or_directories...> [options]
 - Pass `--tag-new` to immediately tag imports using the existing OpenAI tagging workflow (honors `--tag-model`, `--tag-prompt`, and `--tag-workers`).
 - Enable `--ai-rename` to request a descriptive filename from OpenAI. The `tagging_config.json` file supplies the API key and optionally a `rename_prompt` value for this feature. Provide `--rename-model` or `--rename-prompt` to override the defaults ad hoc.
 - Set a shared `--title` for all imported files or allow the tool to derive one from the filename/AI slug.
-- Thumbnails are generated automatically in `gallery/thumbs/`. Run the command with
+- Thumbnails are generated automatically in the `gallery/thumbs/<size>/` directories. Run the command with
   `--regenerate-thumbnails [--force-thumbnails]` to refresh thumbnails for existing
   entries without importing new files.
 

--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -261,6 +261,27 @@ header.top-bar .search-bar {
   <div class="viewer-meta"><a id="viewerRaw" href="" target="_blank">Raw file</a></div>
 </div>
 <script>
+const sizeClassToKey = {
+  'gallery-small': 'small',
+  'gallery-medium': 'medium',
+  'gallery-large': 'large',
+};
+
+function currentSizeKey() {
+  const selector = document.getElementById('sizeSelector');
+  const className = selector ? selector.value : 'gallery-medium';
+  return sizeClassToKey[className] || 'medium';
+}
+
+function resolveThumbnails(item, fallback) {
+  const thumbs = item.thumbnails || {};
+  return {
+    small: thumbs.small || fallback,
+    medium: thumbs.medium || fallback,
+    large: thumbs.large || fallback,
+  };
+}
+
 async function loadImages() {
   const response = await fetch('metadata.json');
   const data = await response.json();
@@ -283,7 +304,10 @@ async function loadImages() {
     const tagsArr = item.tags || [];
     card.dataset.tags = tagsArr.map(t => t.toLowerCase()).join('\n');
     const imgPath = 'images/' + item.filename;
-    const thumbPath = item.thumbnail ? item.thumbnail : imgPath;
+    const fallbackThumb = item.thumbnail ? item.thumbnail : imgPath;
+    const thumbPaths = resolveThumbnails(item, fallbackThumb);
+    const thumbKey = currentSizeKey();
+    const thumbPath = thumbPaths[thumbKey];
     const created = item.created_at
       ? new Date(item.created_at * 1000)
           .toISOString()
@@ -298,7 +322,7 @@ async function loadImages() {
         : '';
     card.innerHTML =
       '<a href="' + imgPath + '" class="thumb">' +
-      '<img data-src="' + thumbPath + '" data-full="' + imgPath + '" alt="' + title + '" loading="lazy"></a>' +
+      '<img data-src="' + thumbPath + '" data-thumb-small="' + thumbPaths.small + '" data-thumb-medium="' + thumbPaths.medium + '" data-thumb-large="' + thumbPaths.large + '" data-full="' + imgPath + '" alt="' + title + '" loading="lazy"></a>' +
       '<div class="meta"><strong>' + (title || item.id) + '</strong>' +
       '<span class="created"><br>' + created + '</span>' +
       tagsHtml + '<br><a href="' +
@@ -308,7 +332,13 @@ async function loadImages() {
     if (tagsSpan) {
       tagsSpan.title = tagsArr.join(', ');
     }
-    const index = viewerData.push({ src: imgPath, thumb: thumbPath, title: title || item.id }) - 1;
+    const index =
+      viewerData.push({
+        src: imgPath,
+        thumb: thumbPath,
+        thumbs: thumbPaths,
+        title: title || item.id,
+      }) - 1;
     card.dataset.index = String(index);
     gallery.appendChild(card);
     const link = card.querySelector('a.thumb');
@@ -440,6 +470,27 @@ function makeSearchFn(expr) {
   }
   return parseExpr();
 }
+function updateThumbnailsForSize(sizeKey) {
+  const images = document.querySelectorAll('.image-card img');
+  images.forEach(img => {
+    let nextSrc = img.dataset[`thumb${sizeKey.charAt(0).toUpperCase() + sizeKey.slice(1)}`];
+    if (!nextSrc) {
+      nextSrc = img.dataset.src;
+    }
+    if (!nextSrc) return;
+    img.dataset.src = nextSrc;
+    if (img.hasAttribute('src')) {
+      img.src = nextSrc;
+    }
+  });
+  viewerData = viewerData.map(item => {
+    if (!item.thumbs) return item;
+    const updated = { ...item };
+    updated.thumb = item.thumbs[sizeKey] || item.thumb;
+    return updated;
+  });
+}
+
 function changeSize() {
   const gallery = document.getElementById('gallery');
   const size = document.getElementById('sizeSelector').value;
@@ -447,6 +498,8 @@ function changeSize() {
   if (typeof sessionStorage !== 'undefined') {
     sessionStorage.setItem('size', size);
   }
+  const sizeKey = sizeClassToKey[size] || 'medium';
+  updateThumbnailsForSize(sizeKey);
 }
 function resetFilters() {
   const textEl = document.getElementById('searchBox');

--- a/src/chatgpt_library_archiver/importer.py
+++ b/src/chatgpt_library_archiver/importer.py
@@ -250,9 +250,7 @@ def import_images(
 
             created_at = datetime.now(timezone.utc).timestamp()
             thumb_rels = thumbnails.thumbnail_relative_paths(filename)
-            thumb_paths = {
-                size: gallery_path / rel for size, rel in thumb_rels.items()
-            }
+            thumb_paths = {size: gallery_path / rel for size, rel in thumb_rels.items()}
             thumbnails.create_thumbnails(dest, thumb_paths, reporter=reporter)
 
             record = {

--- a/src/chatgpt_library_archiver/importer.py
+++ b/src/chatgpt_library_archiver/importer.py
@@ -249,9 +249,11 @@ def import_images(
                 shutil.move(source_path, dest)
 
             created_at = datetime.now(timezone.utc).timestamp()
-            thumb_rel = thumbnails.thumbnail_relative_path(filename)
-            thumb_path = gallery_path / thumb_rel
-            thumbnails.create_thumbnail(dest, thumb_path, reporter=reporter)
+            thumb_rels = thumbnails.thumbnail_relative_paths(filename)
+            thumb_paths = {
+                size: gallery_path / rel for size, rel in thumb_rels.items()
+            }
+            thumbnails.create_thumbnails(dest, thumb_paths, reporter=reporter)
 
             record = {
                 "id": uuid.uuid4().hex,
@@ -266,7 +268,8 @@ def import_images(
                 "conversation_id": None,
                 "message_id": None,
                 "conversation_link": item.conversation_link,
-                "thumbnail": thumb_rel,
+                "thumbnails": thumb_rels,
+                "thumbnail": thumb_rels["medium"],
             }
             data.append(record)
             imported.append(record)

--- a/src/chatgpt_library_archiver/incremental_downloader.py
+++ b/src/chatgpt_library_archiver/incremental_downloader.py
@@ -78,9 +78,7 @@ def main(tag_new: bool = False) -> None:
                 thumb_paths = {
                     size: gallery_root / rel for size, rel in thumb_rels.items()
                 }
-                thumbnails.create_thumbnails(
-                    filepath, thumb_paths, reporter=progress
-                )
+                thumbnails.create_thumbnails(filepath, thumb_paths, reporter=progress)
                 meta["thumbnails"] = thumb_rels
                 meta["thumbnail"] = thumb_rels["medium"]
                 return (True, meta)

--- a/src/chatgpt_library_archiver/incremental_downloader.py
+++ b/src/chatgpt_library_archiver/incremental_downloader.py
@@ -74,10 +74,15 @@ def main(tag_new: bool = False) -> None:
                     f.write(response.content)
 
                 meta["filename"] = filename
-                thumb_rel = thumbnails.thumbnail_relative_path(filename)
-                thumb_path = gallery_root / thumb_rel
-                thumbnails.create_thumbnail(filepath, thumb_path, reporter=progress)
-                meta["thumbnail"] = thumb_rel
+                thumb_rels = thumbnails.thumbnail_relative_paths(filename)
+                thumb_paths = {
+                    size: gallery_root / rel for size, rel in thumb_rels.items()
+                }
+                thumbnails.create_thumbnails(
+                    filepath, thumb_paths, reporter=progress
+                )
+                meta["thumbnails"] = thumb_rels
+                meta["thumbnail"] = thumb_rels["medium"]
                 return (True, meta)
             except Exception as e:
                 return (False, meta["id"], str(e))

--- a/src/chatgpt_library_archiver/thumbnails.py
+++ b/src/chatgpt_library_archiver/thumbnails.py
@@ -10,7 +10,11 @@ from PIL import Image, ImageOps, UnidentifiedImageError
 from .status import StatusReporter
 
 THUMBNAIL_DIR_NAME = "thumbs"
-THUMBNAIL_SIZE: tuple[int, int] = (512, 512)
+THUMBNAIL_SIZES: dict[str, tuple[int, int]] = {
+    "small": (150, 150),
+    "medium": (250, 250),
+    "large": (400, 400),
+}
 
 _RESAMPLING = getattr(Image, "Resampling", Image)
 _LANCZOS = getattr(_RESAMPLING, "LANCZOS", Image.BICUBIC)
@@ -27,10 +31,26 @@ _EXT_TO_FORMAT = {
 }
 
 
-def thumbnail_relative_path(filename: str) -> str:
-    """Return the metadata value for a thumbnail path."""
+def thumbnail_relative_path(filename: str, size: str = "medium") -> str:
+    """Return the metadata value for a thumbnail path.
 
-    return f"{THUMBNAIL_DIR_NAME}/{filename}"
+    Parameters
+    ----------
+    filename:
+        The image filename the thumbnail corresponds to.
+    size:
+        The gallery size bucket (``small``, ``medium``, ``large``).
+    """
+
+    if size not in THUMBNAIL_SIZES:
+        raise ValueError(f"Unsupported thumbnail size: {size}")
+    return f"{THUMBNAIL_DIR_NAME}/{size}/{filename}"
+
+
+def thumbnail_relative_paths(filename: str) -> dict[str, str]:
+    """Return relative thumbnail paths for every configured size."""
+
+    return {size: thumbnail_relative_path(filename, size) for size in THUMBNAIL_SIZES}
 
 
 def _infer_format(dest: Path, image: Image.Image) -> str:
@@ -42,30 +62,61 @@ def _infer_format(dest: Path, image: Image.Image) -> str:
     return "PNG"
 
 
-def create_thumbnail(
-    source: Path, dest: Path, *, reporter: StatusReporter | None = None
+def _prepare_for_format(img: Image.Image, fmt: str) -> tuple[Image.Image, dict[str, object]]:
+    """Return an image and keyword arguments tuned for the target format."""
+
+    save_kwargs: dict[str, object] = {}
+    fmt = fmt.upper()
+    if fmt == "JPEG":
+        if img.mode not in ("RGB", "L"):
+            img = img.convert("RGB")
+        save_kwargs.update({
+            "quality": 80,
+            "optimize": True,
+            "progressive": True,
+            "subsampling": 2,
+        })
+    elif fmt == "PNG":
+        if img.mode not in ("RGB", "RGBA", "L"):
+            img = img.convert("RGBA")
+        save_kwargs.update({
+            "optimize": True,
+            "compress_level": 9,
+        })
+    elif fmt == "WEBP":
+        if img.mode not in ("RGB", "RGBA", "L"):
+            img = img.convert("RGBA")
+        save_kwargs.update({
+            "quality": 80,
+            "method": 6,
+        })
+    elif fmt == "GIF":
+        if img.mode not in ("P", "L"):
+            img = img.convert("P", palette=Image.ADAPTIVE)
+        save_kwargs["optimize"] = True
+    return img, save_kwargs
+
+
+def create_thumbnails(
+    source: Path, dest_map: dict[str, Path], *, reporter: StatusReporter | None = None
 ) -> None:
-    """Create a thumbnail for ``source`` at ``dest``."""
+    """Create thumbnails for ``source`` at every ``dest`` path provided."""
 
     if reporter is not None:
-        reporter.log_status("Generating thumbnail for", source.name)
-    dest.parent.mkdir(parents=True, exist_ok=True)
+        reporter.log_status("Generating thumbnails for", source.name)
     try:
         with Image.open(source) as img:
-            img = ImageOps.exif_transpose(img)
-            img.thumbnail(THUMBNAIL_SIZE, _LANCZOS)
-            fmt = _infer_format(dest, img)
-            save_kwargs = {}
-            if fmt == "JPEG":
-                if img.mode not in ("RGB", "L"):
-                    img = img.convert("RGB")
-                save_kwargs["quality"] = 85
-                save_kwargs["optimize"] = True
-            elif fmt == "PNG":
-                if img.mode == "P":
-                    img = img.convert("RGBA")
-                save_kwargs["optimize"] = True
-            img.save(dest, fmt, **save_kwargs)
+            base = ImageOps.exif_transpose(img)
+            for size, dest in dest_map.items():
+                if size not in THUMBNAIL_SIZES:
+                    raise ValueError(f"Unsupported thumbnail size: {size}")
+                target_size = THUMBNAIL_SIZES[size]
+                thumb = base.copy()
+                thumb.thumbnail(target_size, _LANCZOS)
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                fmt = _infer_format(dest, thumb)
+                prepared, save_kwargs = _prepare_for_format(thumb, fmt)
+                prepared.save(dest, fmt, **save_kwargs)
     except (FileNotFoundError, UnidentifiedImageError, OSError) as exc:
         raise RuntimeError(f"Failed to create thumbnail for {source}: {exc}") from exc
 
@@ -87,7 +138,7 @@ def regenerate_thumbnails(
     images_dir = gallery_root / "images"
 
     entries = list(metadata)
-    pending: list[tuple[str, Path, Path]] = []
+    pending: list[tuple[str, Path, dict[str, Path]]] = []
 
     for entry in entries:
         filename = entry.get("filename")
@@ -97,20 +148,24 @@ def regenerate_thumbnails(
         if not source.is_file():
             continue
         processed.append(filename)
-        thumb_rel = thumbnail_relative_path(filename)
-        thumb_path = gallery_root / thumb_rel
-        need_create = force or not thumb_path.exists()
+        thumb_rel_map = thumbnail_relative_paths(filename)
+        thumb_path_map = {size: gallery_root / rel for size, rel in thumb_rel_map.items()}
+        need_create = force or any(not path.exists() for path in thumb_path_map.values())
         if need_create:
-            pending.append((filename, source, thumb_path))
-        if entry.get("thumbnail") != thumb_rel:
-            entry["thumbnail"] = thumb_rel
+            pending.append((filename, source, thumb_path_map))
+        if entry.get("thumbnails") != thumb_rel_map:
+            entry["thumbnails"] = thumb_rel_map
+            updated = True
+        medium_rel = thumb_rel_map["medium"]
+        if entry.get("thumbnail") != medium_rel:
+            entry["thumbnail"] = medium_rel
             updated = True
 
     if reporter is not None and pending:
         reporter.add_total(len(pending))
 
-    for _filename, source, thumb_path in pending:
-        create_thumbnail(source, thumb_path, reporter=reporter)
+    for _filename, source, thumb_paths in pending:
+        create_thumbnails(source, thumb_paths, reporter=reporter)
         if reporter is not None:
             reporter.advance()
 

--- a/src/chatgpt_library_archiver/thumbnails.py
+++ b/src/chatgpt_library_archiver/thumbnails.py
@@ -62,7 +62,9 @@ def _infer_format(dest: Path, image: Image.Image) -> str:
     return "PNG"
 
 
-def _prepare_for_format(img: Image.Image, fmt: str) -> tuple[Image.Image, dict[str, object]]:
+def _prepare_for_format(
+    img: Image.Image, fmt: str
+) -> tuple[Image.Image, dict[str, object]]:
     """Return an image and keyword arguments tuned for the target format."""
 
     save_kwargs: dict[str, object] = {}
@@ -70,26 +72,32 @@ def _prepare_for_format(img: Image.Image, fmt: str) -> tuple[Image.Image, dict[s
     if fmt == "JPEG":
         if img.mode not in ("RGB", "L"):
             img = img.convert("RGB")
-        save_kwargs.update({
-            "quality": 80,
-            "optimize": True,
-            "progressive": True,
-            "subsampling": 2,
-        })
+        save_kwargs.update(
+            {
+                "quality": 80,
+                "optimize": True,
+                "progressive": True,
+                "subsampling": 2,
+            }
+        )
     elif fmt == "PNG":
         if img.mode not in ("RGB", "RGBA", "L"):
             img = img.convert("RGBA")
-        save_kwargs.update({
-            "optimize": True,
-            "compress_level": 9,
-        })
+        save_kwargs.update(
+            {
+                "optimize": True,
+                "compress_level": 9,
+            }
+        )
     elif fmt == "WEBP":
         if img.mode not in ("RGB", "RGBA", "L"):
             img = img.convert("RGBA")
-        save_kwargs.update({
-            "quality": 80,
-            "method": 6,
-        })
+        save_kwargs.update(
+            {
+                "quality": 80,
+                "method": 6,
+            }
+        )
     elif fmt == "GIF":
         if img.mode not in ("P", "L"):
             img = img.convert("P", palette=Image.ADAPTIVE)
@@ -149,8 +157,12 @@ def regenerate_thumbnails(
             continue
         processed.append(filename)
         thumb_rel_map = thumbnail_relative_paths(filename)
-        thumb_path_map = {size: gallery_root / rel for size, rel in thumb_rel_map.items()}
-        need_create = force or any(not path.exists() for path in thumb_path_map.values())
+        thumb_path_map = {
+            size: gallery_root / rel for size, rel in thumb_rel_map.items()
+        }
+        need_create = force or any(
+            not path.exists() for path in thumb_path_map.values()
+        )
         if need_create:
             pending.append((filename, source, thumb_path_map))
         if entry.get("thumbnails") != thumb_rel_map:

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -134,7 +134,8 @@ def test_incremental_download_and_gallery(monkeypatch, tmp_path):
     for item in data:
         if item["id"] == "2":
             assert item.get("tags") == ["t"]
-        assert item["thumbnail"].startswith("thumbs/")
+        assert item["thumbnail"].startswith("thumbs/medium/")
+        assert item["thumbnails"]["medium"].startswith("thumbs/medium/")
 
     html = html_path.read_text()
     assert "metadata.json" in html

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -51,8 +51,12 @@ def test_import_single_file_move(monkeypatch, tmp_path):
     assert metadata[0]["conversation_link"] == "https://chat.openai.com/c/abc#def"
     assert isinstance(metadata[0]["created_at"], float)
     assert metadata[0]["thumbnail"] == f"thumbs/medium/{imported[0]['filename']}"
-    assert metadata[0]["thumbnails"]["small"] == f"thumbs/small/{imported[0]['filename']}"
-    assert metadata[0]["thumbnails"]["large"] == f"thumbs/large/{imported[0]['filename']}"
+    assert (
+        metadata[0]["thumbnails"]["small"] == f"thumbs/small/{imported[0]['filename']}"
+    )
+    assert (
+        metadata[0]["thumbnails"]["large"] == f"thumbs/large/{imported[0]['filename']}"
+    )
 
     metadata = json.loads((gallery_root / "metadata.json").read_text())
     assert metadata[0]["tags"] == ["tag1", "tag2"]


### PR DESCRIPTION
## Summary
- generate small, medium, and large thumbnails with tuned compression settings
- update the gallery viewer to load the appropriate thumbnail for each layout size
- refresh tests and documentation for the new multi-size thumbnail metadata

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68db5bbb7200832f88283ace9b6eac25