### PR TITLE
fix: report thumbnail progress when workers run

### DIFF
--- a/tests/test_thumbnails.py
+++ b/tests/test_thumbnails.py
@@ -1,4 +1,6 @@
 import io
+import queue
+from concurrent.futures import Future
 
 import pytest
 from PIL import Image
@@ -13,6 +15,37 @@ def _sample_png_bytes() -> bytes:
 
 
 PNG_BYTES = _sample_png_bytes()
+
+
+class RecordingReporter:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+        self.total: int = 0
+        self.advanced: int = 0
+
+    def log_status(self, action: str, detail: str) -> None:
+        self.messages.append((action, detail))
+
+    def add_total(self, amount: int) -> None:
+        self.total += amount
+
+    def advance(self, amount: int = 1) -> None:
+        self.advanced += amount
+
+
+def test_create_thumbnails_logs_start_and_finish(tmp_path):
+    source = tmp_path / "image.png"
+    source.write_bytes(PNG_BYTES)
+    dest_map = {size: tmp_path / f"{size}.png" for size in thumbnails.THUMBNAIL_SIZES}
+
+    reporter = RecordingReporter()
+
+    thumbnails.create_thumbnails(source, dest_map, reporter=reporter)
+
+    assert reporter.messages == [
+        ("Generating thumbnails for", "image.png"),
+        ("Finished generating thumbnails for", "image.png"),
+    ]
 
 
 def test_regenerate_thumbnails_parallel_uses_executor(monkeypatch, tmp_path):
@@ -47,6 +80,7 @@ def test_regenerate_thumbnails_parallel_uses_executor(monkeypatch, tmp_path):
     class DummyExecutor:
         def __init__(self, **kwargs):
             executor_kwargs.append(kwargs)
+            self._max_workers = kwargs.get("max_workers", 1)
 
         def __enter__(self):
             return self
@@ -82,6 +116,90 @@ def test_regenerate_thumbnails_parallel_uses_executor(monkeypatch, tmp_path):
         assert thumbs["small"] == f"thumbs/small/{name}"
         assert thumbs["medium"] == f"thumbs/medium/{name}"
         assert thumbs["large"] == f"thumbs/large/{name}"
+
+
+def test_regenerate_thumbnails_parallel_reports_start_and_finish(monkeypatch, tmp_path):
+    gallery_root = tmp_path
+    images_dir = gallery_root / "images"
+    images_dir.mkdir()
+
+    filenames = ["one.png", "two.png", "three.png"]
+    for name in filenames:
+        (images_dir / name).write_bytes(PNG_BYTES)
+
+    metadata = [{"filename": name} for name in filenames]
+
+    executor_kwargs: list[dict[str, object]] = []
+
+    class DummyFuture(Future):
+        def __init__(self, fn, *args):  # noqa: ANN001
+            super().__init__()
+            try:
+                result = fn(*args)
+            except Exception as exc:  # noqa: BLE001
+                self.set_exception(exc)
+            else:
+                self.set_result(result)
+
+    class DummyExecutor:
+        def __init__(self, **kwargs):
+            executor_kwargs.append(kwargs)
+            self._max_workers = kwargs.get("max_workers", 2)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):  # noqa: ANN001, D401
+            return False
+
+        def submit(self, fn, *args):  # noqa: ANN001
+            return DummyFuture(fn, *args)
+
+    class DummyContext:
+        def Queue(self):  # noqa: D401, ANN001
+            return queue.Queue()
+
+    reporter = RecordingReporter()
+
+    monkeypatch.setattr(thumbnails, "ProcessPoolExecutor", DummyExecutor)
+    monkeypatch.setattr(
+        thumbnails.multiprocessing, "get_context", lambda: DummyContext()
+    )
+
+    processed, updated = thumbnails.regenerate_thumbnails(
+        gallery_root,
+        metadata,
+        force=True,
+        reporter=reporter,
+        max_workers=2,
+    )
+
+    assert len(executor_kwargs) == 1
+    kwargs = executor_kwargs[0]
+    assert kwargs.get("max_workers") == 2
+    assert isinstance(kwargs.get("mp_context"), DummyContext)
+    assert sorted(processed) == sorted(filenames)
+    assert updated
+    assert reporter.total == len(filenames)
+    assert reporter.advanced == len(filenames)
+
+    starts = {
+        detail
+        for action, detail in reporter.messages
+        if action == "Generating thumbnails for"
+    }
+    finishes = {
+        detail
+        for action, detail in reporter.messages
+        if action == "Finished generating thumbnails for"
+    }
+    assert starts == finishes == set(filenames)
+
+    positions = {message: idx for idx, message in enumerate(reporter.messages)}
+    for name in filenames:
+        start_key = ("Generating thumbnails for", name)
+        finish_key = ("Finished generating thumbnails for", name)
+        assert positions[start_key] < positions[finish_key]
 
 
 def test_regenerate_thumbnails_rejects_invalid_worker_count(tmp_path):


### PR DESCRIPTION
## Summary
- ensure thumbnail workers communicate start/finish events so status logging tracks actual execution
- log completion inside `create_thumbnails` and extend regression tests to cover logging order

## Testing
- PYTHONPATH=src pytest
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68db6626f054832f86770168b18f87a7