### PR TITLE
Fix gallery metadata fetch caching

### DIFF
--- a/src/chatgpt_library_archiver/gallery_index.html
+++ b/src/chatgpt_library_archiver/gallery_index.html
@@ -401,7 +401,7 @@ function resolveThumbnails(item, fallback, fullSrc) {
 }
 
 async function loadImages() {
-  const response = await fetch('metadata.json');
+  const response = await fetch('metadata.json', { cache: 'no-store' });
   const data = await response.json();
   const gallery = document.getElementById('gallery');
   const observer = new IntersectionObserver((entries, obs) => {


### PR DESCRIPTION
## Summary
- disable browser caching of gallery metadata by fetching with `cache: 'no-store'`

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68dc98d69d04832f8c3f4ba53111fbd6