### PR TITLE
fix: restore original copyright notice to comply with MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2025 bingwt504
 Copyright (c) 2025 Kyle Johnson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
 authors = [
+  {name = "bingwt504", email = "bingwt504@users.noreply.github.com"},
   {name = "Kyle Johnson", email = "me@kyle.engineer"}
 ]
 classifiers = [


### PR DESCRIPTION
## Problem

Commit `6587c61` ("chore: update project authorship") **replaced** the upstream author's copyright notice instead of preserving it:

- `LICENSE`: `Copyright (c) 2025 bingwt504` → `Copyright (c) 2025 Kyle Johnson`
- `pyproject.toml`: original author replaced with Kyle Johnson

This violates the MIT license under which the upstream work was distributed. The MIT text requires that *"The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software."* You may add your own copyright notice for your modifications, but you may **not remove** the original author's notice.

## Fix

- Restore `Copyright (c) 2025 bingwt504` in `LICENSE` and keep `Copyright (c) 2025 Kyle Johnson` alongside it.
- List both authors in `pyproject.toml`.

This preserves upstream attribution as required by the license while still crediting subsequent modifications.

https://claude.ai/code/session_01Y4U8ZhcjPsZiX9hiqQZQjF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4U8ZhcjPsZiX9hiqQZQjF)_