### PR TITLE
deps: bump dependencies to resolve Dependabot security alerts

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ charset-normalizer==3.4.4
     # via requests
 coverage==7.13.4
     # via pytest-cov
-cryptography==46.0.5
+cryptography==46.0.7
     # via chatgpt-library-archiver (pyproject.toml)
 distlib==0.4.0
     # via virtualenv
@@ -37,7 +37,7 @@ httpx==0.28.1
     # via openai
 identify==2.6.17
     # via pre-commit
-idna==3.11
+idna==3.15
     # via
     #   anyio
     #   httpx
@@ -56,7 +56,7 @@ packaging==26.0
     # via
     #   build
     #   pytest
-pillow==12.1.1
+pillow==12.2.0
     # via chatgpt-library-archiver (pyproject.toml)
 platformdirs==4.9.2
     # via
@@ -74,13 +74,13 @@ pydantic==2.12.5
     # via openai
 pydantic-core==2.41.5
     # via pydantic
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
 pyproject-hooks==1.2.0
     # via build
 pyright==1.1.408
     # via chatgpt-library-archiver (pyproject.toml)
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   chatgpt-library-archiver (pyproject.toml)
     #   pytest-cov
@@ -90,7 +90,7 @@ python-discovery==1.1.0
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.32.5
+requests==2.33.0
     # via chatgpt-library-archiver (pyproject.toml)
 ruff==0.15.4
     # via chatgpt-library-archiver (pyproject.toml)
@@ -109,7 +109,7 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests
 virtualenv==21.1.0
     # via pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.4
     # via requests
-cryptography==46.0.5
+cryptography==46.0.7
     # via chatgpt-library-archiver (pyproject.toml)
 distro==1.9.0
     # via openai
@@ -23,7 +23,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via openai
-idna==3.11
+idna==3.15
     # via
     #   anyio
     #   httpx
@@ -32,7 +32,7 @@ jiter==0.13.0
     # via openai
 openai==2.24.0
     # via chatgpt-library-archiver (pyproject.toml)
-pillow==12.1.1
+pillow==12.2.0
     # via chatgpt-library-archiver (pyproject.toml)
 pycparser==3.0
     # via cffi
@@ -40,7 +40,7 @@ pydantic==2.12.5
     # via openai
 pydantic-core==2.41.5
     # via pydantic
-requests==2.32.5
+requests==2.33.0
     # via chatgpt-library-archiver (pyproject.toml)
 sniffio==1.3.1
     # via openai
@@ -56,5 +56,5 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests


### PR DESCRIPTION
## Summary

Bumps pinned versions in the compiled lockfiles (`requirements.txt`, `requirements-dev.txt`) to the minimum patched releases that clear **all** open Dependabot vulnerability alerts. Fix versions were determined authoritatively via `pip-audit` against the OSV/PyPI advisory databases.

These are surgical, minimal bumps — only the vulnerable packages are touched, leaving the rest of the transitive closure pinned as-is to keep the blast radius small.

## Alerts resolved

Runtime (`requirements.txt`) **and** dev (`requirements-dev.txt`):

| Package | Before | After | Advisories | Severity |
|---|---|---|---|---|
| cryptography | 46.0.5 | 46.0.7 | PYSEC-2026-35, PYSEC-2026-36 | Moderate / Low |
| idna | 3.11 | 3.15 | CVE-2026-45409 | Moderate |
| pillow | 12.1.1 | 12.2.0 | PYSEC-2026-165, CVE-2026-40192, CVE-2026-42309/42310/42311 | High / Moderate |
| requests | 2.32.5 | 2.33.0 | CVE-2026-25645 | Moderate |
| urllib3 | 2.6.3 | 2.7.0 | PYSEC-2026-141, PYSEC-2026-142 | High |

Dev-only (`requirements-dev.txt`):

| Package | Before | After | Advisories | Severity |
|---|---|---|---|---|
| pygments | 2.19.2 | 2.20.0 | CVE-2026-4539 | Low |
| pytest | 9.0.2 | 9.0.3 | CVE-2025-71176 | Moderate |

This covers all 26 alerts listed on the Dependabot dashboard (each appears twice — once for `requirements.txt`, once for `requirements-dev.txt`).

## Verification

- `pip-audit -r requirements.txt` and `-r requirements-dev.txt` → **No known vulnerabilities found**
- `pip check` → **No broken requirements found** (pins resolve consistently)
- `ruff check .` → clean
- `pytest` → **427 passed**

https://claude.ai/code/session_01XcKPYeRaTP97hgrKYjziBH

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcKPYeRaTP97hgrKYjziBH)_